### PR TITLE
Update node-provisioning.mdx

### DIFF
--- a/docs/concepts/nodes/node-operation/node-provisioning.mdx
+++ b/docs/concepts/nodes/node-operation/node-provisioning.mdx
@@ -8,15 +8,15 @@ description: Hardware, networking and Operating system setup for a Flow node
 
 The hardware your Node will need varies depending on the role your Node will play in the Flow network. For an overview of the differences see the [Node Roles Overview](./node-roles.mdx).
 
-| Node Type | CPU | Memory | Disk | Example GCP Instance |
-|:----------------:| ---------:| ------:| ------:|:--------------:|
-| **Collection**   |  4 cores  | 32 GB  | 200 GB | n2-highmem-4   |
-| **Consensus**    |  2 cores  | 16 GB  | 200 GB | n2-standard-4  |
-| **Execution**    | 64 cores  | 800 GB |  9 TB  | n2-highmem-128 |
-| **Verification** |  2 cores  | 16 GB  | 200 GB | n2-highmem-2   |
-| **Access**       |  4 cores | 16 GB  | 750 GB | n2-standard-4   |
-| **Observer**     |  2 cores  | 4 GB   | 300 GB | n2-standard-4  |
-| **Archive**      | 32 cores  | 800 GB |  2 TB  | m3-ultramem-32 |
+| Node Type | CPU | Memory | Disk | Example GCP Instance | Example AWS Instance |
+|:----------------:| ---------:| ------:| ------:|:--------------:|:--------------:|
+| **Collection**   |  4 cores  | 32 GB  | 200 GB | n2-highmem-4   | r6i.xlarge     |
+| **Consensus**    |  2 cores  | 16 GB  | 200 GB | n2-standard-4  | m6a.xlarge     |
+| **Execution**    | 64 cores  | 800 GB |  9 TB  | n2-highmem-128 | r6i.32xlarge   |
+| **Verification** |  2 cores  | 16 GB  | 200 GB | n2-highmem-2   | r6a.large      |
+| **Access**       |  4 cores | 16 GB  | 750 GB | n2-standard-4   | m6i.xlarge     |
+| **Observer**     |  2 cores  | 4 GB   | 300 GB | n2-standard-4  | m6i.xlarge     |
+| **Archive**      | 32 cores  | 800 GB |  2 TB  | m3-ultramem-32 | x2idn.16xlarge |
 
 _Note: The above numbers represent our current best estimate for the state of the network. These will be actively updated as we continue benchmarking the network's performance._
 


### PR DESCRIPTION
Added example AWS instance types for community members who wants to use Amazon cloud. Matching instance types are chosen hardware requirements and example GCP instances.