### PR TITLE
Add Hybrid Custody Scaffold & update repo links

### DIFF
--- a/docs/concepts/hybrid-custody/get-started.mdx
+++ b/docs/concepts/hybrid-custody/get-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Get Started with Account Linking
+title: Get Started with Hybrid Custody
 ---
 
 There are two sides to Hybrid Custody support - delegation and usage. 
@@ -12,7 +12,7 @@ From the usage perspective, apps would want to get information about a user's li
 assets, enable account & asset management, and even facilitate cross account interactions - think of this from the
 perspective of a wallet or NFT marketplace.
 
-<Callout type="info">
+<Callout type="warning">
 
 Note that the documentation on Hybrid Custody covers the current state and will likely differ from the final
 implementation. Builders should be aware that breaking changes may follow before reaching a final consensus on
@@ -23,6 +23,21 @@ implementation. Interested in shaping the conversation? [Join in!](https://githu
 In either case, you'll want to do the following to get started implementing Hybrid Custody in your application:
 
 1. [Install Flow CLI](https://developers.flow.com/tooling/flow-cli/install)
-1. Copy the contents of [restricted-child-account](https://github.com/flowtyio/restricted-child-account) into your
-   project (CLI scaffold to follow shortly!)
-1. Start building!
+1. Run the following commands:
+   
+   ```sh
+   flow setup learn-hybrid-custody --scaffold
+   ```
+
+   You'll be asked to select the [scaffold](https://github.com/onflow/hybrid-custody-scaffold) number for this scaffold,
+   enter `4` for Hybrid Custody Project
+
+   ```sh
+   ✔ Enter the scaffold number: 4
+   ```
+
+1. Change to your project directory and start building!
+
+   ```sh
+   cd learn-hybrid-custody
+   ```

--- a/docs/concepts/hybrid-custody/get-started.mdx
+++ b/docs/concepts/hybrid-custody/get-started.mdx
@@ -23,21 +23,20 @@ implementation. Interested in shaping the conversation? [Join in!](https://githu
 In either case, you'll want to do the following to get started implementing Hybrid Custody in your application:
 
 1. [Install Flow CLI](https://developers.flow.com/tooling/flow-cli/install)
-1. Run the following commands:
+1. Create a project from the [Hybrid Custody scaffold](https://github.com/onflow/hybrid-custody-scaffold):
    
    ```sh
-   flow setup learn-hybrid-custody --scaffold
+   flow setup build-hybrid-custody --scaffold
    ```
 
-   You'll be asked to select the [scaffold](https://github.com/onflow/hybrid-custody-scaffold) number for this scaffold,
-   enter `4` for Hybrid Custody Project
+   You'll be asked to select the scaffold number for this scaffold, enter `4` for Hybrid Custody Project
 
    ```sh
    ✔ Enter the scaffold number: 4
    ```
 
-1. Change to your project directory and start building!
+1. Change to your new project directory and follow the README to get started!
 
    ```sh
-   cd learn-hybrid-custody
+   cd build-hybrid-custody
    ```

--- a/docs/concepts/hybrid-custody/guides/linking-accounts.mdx
+++ b/docs/concepts/hybrid-custody/guides/linking-accounts.mdx
@@ -124,8 +124,8 @@ Linking an account is the process of delegating account access via AuthAccount C
 
 Since account delegation is mediated by developer-defined rules, you should make sure to first configure the resources
 that contain those rules. Contracts involved in defining and enforcing this ruleset are
-[`CapabilityFilter`](https://github.com/Flowtyio/restricted-child-account/blob/main/contracts/CapabilityFilter.cdc) and
-[`CapabilityFactory`](https://github.com/Flowtyio/restricted-child-account/blob/main/contracts/CapabilityFactory.cdc).
+[`CapabilityFilter`](https://github.com/onflow/hybrid-custody/blob/main/contracts/CapabilityFilter.cdc) and
+[`CapabilityFactory`](https://github.com/onflow/hybrid-custody/blob/main/contracts/CapabilityFactory.cdc).
 The former enumerates those types that are/aren't accessible from a child account while the latter enables the access of
 those allowable Capabilities such that the returned values can be properly typed - e.g. retrieving a Capability that can
 be cast to `Capability<&NonFungibleToken.Collection>` for example.

--- a/docs/concepts/hybrid-custody/guides/walletless-onboarding.mdx
+++ b/docs/concepts/hybrid-custody/guides/walletless-onboarding.mdx
@@ -34,7 +34,7 @@ simple in-app custodial method and funded account creation, transaction, and sto
 account. **Don't let these non-technical considerations keep you from building awesome apps!**
 
 If you're a smart contract developer looking to get started straight away with example walletless onboarding
-transactions, take a look at the [restricted-child-account repo](https://github.com/flowtyio/restricted-child-account).
+transactions, take a look at the [@onflow/hybrid-custody repo](https://github.com/onflow/hybrid-custody).
 
 ## Introduction
 
@@ -108,7 +108,7 @@ import "FungibleToken"
 /// account creation & optional funding.
 ///
 /// For more examples like this, check out the following repo:
-/// https://github.com/flowtyio/restricted-child-account
+/// https://github.com/onflow/hybrid-custody
 ///
 transaction(
     pubKey: String,

--- a/docs/concepts/hybrid-custody/index.mdx
+++ b/docs/concepts/hybrid-custody/index.mdx
@@ -16,7 +16,7 @@ The full Hybrid Custody experience is enabled by three core components:
 - HybridCustody contract - A standard contract enabling users to view and manage their linked accounts
 
 
-<Callout type="info">
+<Callout type="warning">
 
 Note that the documentation on Hybrid Custody covers the current state and will likely differ from the final
 implementation. Builders should be aware that breaking changes may follow before reaching a final consensus on
@@ -30,15 +30,16 @@ implementation. Interested in shaping the conversation? [Join in!](https://githu
    abstract away the complexities of interacting with smart contract powered applications, and focus on creating slick
    user experiences behind familiar Web2 authentication and fiat denominated payments.
 1. Once a user returns to the app with a self-custodial wallet, they can authenticate their wallet-managed account in
-   the app, allowing the app to give the user's main account delegated access to the app managed account.
+   the app, allowing the app to give the user's main account delegated access to the app managed account (albeit with
+   some developer-defined restrictions).
 1. Upon linking, the user's main account - now the "parent" account - adds the app created account - now the "child"
-   account - to a collection of all linked child accounts. At this point, Hybrid Custody is reached
+   account - to a collection of all linked child accounts. At this point, Hybrid Custody is reached!
 
 ### Why Care?
 
-Hybrid Custody grants users full access to their linked child accounts without needing to interface with the child
-account's custodial app, **and** the custodial app can interact with the relevant assets in the child account on behalf
-of the user in a frictionless UX free from transaction prompts.
+Hybrid Custody grants users access to their linked child accounts without needing to interface with the child account's
+custodial app, **and** the custodial app can interact with the relevant assets in the child account on behalf of the
+user in a frictionless UX free from transaction prompts.
 
 > All assets in the app account can now jump the walled garden to play in the rest of the Flow ecosystem.
 


### PR DESCRIPTION
Added CLI scaffold instructions to `hybrid-custody/get-started.mdx` and updated source repo links after transferring ownership and renaming from `flowtyio/restricted-child-account` to [`onflow/hybrid-custody`](https://github.com/onflow/hybrid-custody).