### PR TITLE
Remove pub, priv and pub(set) documentation

### DIFF
--- a/docs/cadence/anti-patterns.mdx
+++ b/docs/cadence/anti-patterns.mdx
@@ -31,7 +31,7 @@ which provides the opportunity for bad actors to take advantage of.
 
 // They could deploy the contract with an Ethereum-style access control list functionality
 
-pub fun transferNFT(id: UInt64, owner: AuthAccount) {
+access(all) fun transferNFT(id: UInt64, owner: AuthAccount) {
     assert(owner(id) == owner.address)
 
     transfer(id)
@@ -43,7 +43,7 @@ pub fun transferNFT(id: UInt64, owner: AuthAccount) {
 // should not be accessible in this function
 // BAD
 
-pub fun transferNFT(id: UInt64, owner: AuthAccount) {
+access(all) fun transferNFT(id: UInt64, owner: AuthAccount) {
     assert(owner(id) == owner.address)
 
     transfer(id)
@@ -201,9 +201,9 @@ if these fields are mistakenly made public.
 Ex:
 
 ```cadence
-pub contract Array {
+access(all) contract Array {
     // array is intended to be initialized to something constant
-    pub let shouldBeConstantArray: [Int]
+    access(all) let shouldBeConstantArray: [Int]
 }
 ```
 
@@ -225,7 +225,7 @@ Make sure that any array or dictionary fields in contracts, structs, or resource
 are `access(contract)` or `access(self)` unless they need to be intentionally made public.
 
 ```cadence
-pub contract Array {
+access(all) contract Array {
     // array is inteded to be initialized to something constant
     access(self) let shouldBeConstantArray: [Int]
 }
@@ -252,14 +252,14 @@ The admin resource can then be `link()`ed to a private path in an admin's accoun
 // Pseudo-code
 
 // BAD
-pub contract Currency {
-    pub resource Admin {
-        pub fun mintTokens()
+access(all) contract Currency {
+    access(all) resource Admin {
+        access(all) fun mintTokens()
     }
 
     // Anyone in the network can call this function
     // And use the Admin resource to mint tokens
-    pub fun createAdmin(): @Admin {
+    access(all) fun createAdmin(): @Admin {
         return <-create Admin()
     }
 }
@@ -267,12 +267,12 @@ pub contract Currency {
 // This contract makes the admin creation private and in the initializer
 // so that only the one who controls the account can mint tokens
 // GOOD
-pub contract Currency {
-    pub resource Admin {
-        pub fun mintTokens()
+access(all) contract Currency {
+    access(all) resource Admin {
+        access(all) fun mintTokens()
 
         // Only an admin can create new Admins
-        pub fun createAdmin(): @Admin {
+        access(all) fun createAdmin(): @Admin {
             return <-create Admin()
         }
     }
@@ -313,14 +313,14 @@ which increments the number that tracks the play IDs and emits an event:
 // Simplified Code
 // BAD
 //
-pub contract TopShot {
+access(all) contract TopShot {
 
     // The Record that is used to track every unique play ID
-    pub var nextPlayID: UInt32
+    access(all) var nextPlayID: UInt32
 
-    pub struct Play {
+    access(all) struct Play {
 
-        pub let playID: UInt32
+        access(all) let playID: UInt32
 
         init() {
 
@@ -348,24 +348,24 @@ that creates the plays.
 // Update contract state in admin resource functions
 // GOOD
 //
-pub contract TopShot {
+access(all) contract TopShot {
 
     // The Record that is used to track every unique play ID
-    pub var nextPlayID: UInt32
+    access(all) var nextPlayID: UInt32
 
-    pub struct Play {
+    access(all) struct Play {
 
-        pub let playID: UInt32
+        access(all) let playID: UInt32
 
         init() {
             self.playID = TopShot.nextPlayID
         }
     }
 
-    pub resource Admin {
+    access(all) resource Admin {
 
         // Protected within the private admin resource
-        pub fun createPlay() {
+        access(all) fun createPlay() {
             // Create the new Play
             var newPlay = Play()
 

--- a/docs/cadence/design-patterns.mdx
+++ b/docs/cadence/design-patterns.mdx
@@ -29,7 +29,7 @@ See [Wikipedia's page on magic numbers](https://en.wikipedia.org/wiki/Magic_numb
 
 ### Solution
 
-Add a public (`pub`), constant (`let`) field, e.g. a `Path` , to the contract responsible for the value,
+Add a public (`access(all)`), constant (`let`) field, e.g. a `Path` , to the contract responsible for the value,
 and set it in the contract's initializer.
 Refer to that value via this public field rather than specifying it manually.
 
@@ -38,8 +38,8 @@ Example Snippet:
 ```cadence
 
 // BAD Practice: Do not hard code storage paths
-pub contract NamedFields {
-    pub resource Test {}
+access(all) contract NamedFields {
+    access(all) resource Test {}
 
     init() {
         // BAD: Hard-coded storage path
@@ -49,11 +49,11 @@ pub contract NamedFields {
 
 // GOOD practice: Instead, use a field
 //
-pub contract NamedFields {
-    pub resource Test {}
+access(all) contract NamedFields {
+    access(all) resource Test {}
 
     // GOOD: field storage path
-    pub let TestStoragePath: StoragePath
+    access(all) let TestStoragePath: StoragePath
 
     init() {
         // assign and access the field here and in transactions
@@ -81,7 +81,7 @@ Your contract, resource or struct has a field or resource that will need to be r
 Make sure that the field can be accessed from a script (using a `PublicAccount`)
 rather than requiring a transaction (using an `AuthAccount`).
 This saves the time and fees required to read a property using a transaction.
-Making the field or function `pub` and exposing it via a `/public/` capability will allow this.
+Making the field or function `access(all)` and exposing it via a `/public/` capability will allow this.
 
 Be careful not to expose any data or functionality that should be kept private when doing so.
 
@@ -92,7 +92,7 @@ Example:
 access(self) let totalSupply: UFix64
 
 // GOOD: Field is public, so it can be read and used by anyone
-pub let totalSupply: UFix64
+access(all) let totalSupply: UFix64
 ```
 
 ## Script-Accessible report
@@ -118,9 +118,9 @@ See [Script-Accessible public field/function](#script-accessible-public-fieldfun
 ### Example Code
 
 ```cadence
-pub contract AContract {
-    pub let BResourceStoragePath: StoragePath
-    pub let BResourcePublicPath: PublicPath
+access(all) contract AContract {
+    access(all) let BResourceStoragePath: StoragePath
+    access(all) let BResourcePublicPath: PublicPath
 
     init() {
         self.BResourceStoragePath = /storage/BResource
@@ -128,15 +128,15 @@ pub contract AContract {
     }
 
     // Resource definition
-    pub resource BResource {
-        pub var c: UInt64
-        pub var d: String
+    access(all) resource BResource {
+        access(all) var c: UInt64
+        access(all) var d: String
 
 
         // Generate a struct with the same fields
         // to return when a script wants to see the fields of the resource
         // without having to return the actual resource
-        pub fun generateReport(): BReportStruct {
+        access(all) fun generateReport(): BReportStruct {
             return BReportStruct(c: self.c, d: self.d)
         }
 
@@ -147,9 +147,9 @@ pub contract AContract {
     }
 
     // Define a struct with the same fields as the resource
-    pub struct BReportStruct {
-        pub var c: UInt64
-        pub var d: String
+    access(all) struct BReportStruct {
+        access(all) var c: UInt64
+        access(all) var d: String
 
         init(c: UInt64, d: String) {
             self.c = c
@@ -172,7 +172,7 @@ transaction {
 import AContract from 0xAContract
 
 // Return the struct with a script
-pub fun main(account: Address): AContract.BReportStruct {
+access(all) fun main(account: Address): AContract.BReportStruct {
     // borrow the resource
     let b = getAccount(account)
         .getCapability(AContract.BResourcePublicPath)
@@ -225,12 +225,12 @@ All fields, functions, types, variables, etc., need to have names that clearly d
 ```cadence
 // BAD: Unclear naming
 //
-pub contract Tax {
+access(all) contract Tax {
     // Do not use abbreviations unless absolutely necessary
-    pub var pcnt: UFix64
+    access(all) var pcnt: UFix64
 
     // Not clear what the function is calculating or what the parameter should be
-    pub fun calculate(num: UFix64): UFix64 {
+    access(all) fun calculate(num: UFix64): UFix64 {
         // What total is this referring to?
         let total = num + (num * self.pcnt)
 
@@ -240,13 +240,13 @@ pub contract Tax {
 
 // GOOD: Clear naming
 //
-pub contract TaxUtilities {
+access(all) contract TaxUtilities {
     // Clearly states what the field is for
-    pub var taxPercentage: UFix64
+    access(all) var taxPercentage: UFix64
 
     // Clearly states that this function calculates the
     // total cost after tax
-    pub fun calculateTotalCostPlusTax(preTaxCost: UFix64): UFix64 {
+    access(all) fun calculateTotalCostPlusTax(preTaxCost: UFix64): UFix64 {
         let postTaxCost = preTaxCost + (preTaxCost * self.taxPercentage)
 
         return postTaxCost
@@ -303,7 +303,7 @@ This could be used when purchasing an NFT to verify that the NFT was deposited i
 
 transaction {
 
-    pub let buyerCollectionRef: &NonFungibleToken.Collection
+    access(all) let buyerCollectionRef: &NonFungibleToken.Collection
 
     prepare(acct: AuthAccount) {
 

--- a/docs/cadence/language/access-control.md
+++ b/docs/cadence/language/access-control.md
@@ -18,7 +18,7 @@ In Flow and Cadence, there are two types of access control:
     by providing references to the objects.
 
 2. Access control within contracts and objects
-   using `pub` and `access` keywords.
+   using `access(all)` and `access` keywords.
 
    For the explanations of the following keywords, we assume that
    the defining type is either a contract, where capability security
@@ -47,7 +47,7 @@ a declaration can be accessed or called.
   This does not allow the declaration to be publicly writable though.
 
   An element is made publicly accessible / by any code
-  by using the `pub` or `access(all)` keywords.
+  by using the `access(all)` or `access(all)` keywords.
 
 - **access(account)** means the declaration is only accessible/visible in the
   scope of the entire account where it is defined. This means that
@@ -76,30 +76,27 @@ a declaration can be accessed or called.
 
 **Access level must be specified for each declaration**
 
-The `(set)` suffix can be used to make variables also publicly writable and mutable.
-
 To summarize the behavior for variable declarations, constant declarations, and fields:
 
-| Declaration kind | Access modifier          | Read scope                                           | Write scope       | Mutate scope      |
-|:-----------------|:-------------------------|:-----------------------------------------------------|:------------------|:------------------|
-| `let`            | `priv` / `access(self)`  | Current and inner                                    | *None*            | Current and inner |
-| `let`            | `access(contract)`       | Current, inner, and containing contract              | *None*            | Current and inner |
-| `let`            | `access(account)`        | Current, inner, and other contracts in same account  | *None*            | Current and inner |
-| `let`            | `pub`,`access(all)`      | **All**                                              | *None*            | Current and inner |
-| `var`            | `access(self)`           | Current and inner                                    | Current and inner | Current and inner |
-| `var`            | `access(contract)`       | Current, inner, and containing contract              | Current and inner | Current and inner |
-| `var`            | `access(account)`        | Current, inner, and other contracts in same account  | Current and inner | Current and inner |
-| `var`            | `pub` / `access(all)`    | **All**                                              | Current and inner | Current and inner |
-| `var`            | `pub(set)`               | **All**                                              | **All**           | **All**           |
+| Declaration kind | Access modifier    | Read scope                                           | Write scope       | Mutate scope      |
+|:-----------------|:-------------------|:-----------------------------------------------------|:------------------|:------------------|
+| `let`            | `access(self)`     | Current and inner                                    | *None*            | Current and inner |
+| `let`            | `access(contract)` | Current, inner, and containing contract              | *None*            | Current and inner |
+| `let`            | `access(account)`  | Current, inner, and other contracts in same account  | *None*            | Current and inner |
+| `let`            | `access(all)`      | **All**                                              | *None*            | Current and inner |
+| `var`            | `access(self)`     | Current and inner                                    | Current and inner | Current and inner |
+| `var`            | `access(contract)` | Current, inner, and containing contract              | Current and inner | Current and inner |
+| `var`            | `access(account)`  | Current, inner, and other contracts in same account  | Current and inner | Current and inner |
+| `var`            | `access(all)`      | **All**                                              | Current and inner | Current and inner |
 
 To summarize the behavior for functions:
 
-| Access modifier          | Access scope                                        |
-|:-------------------------|:----------------------------------------------------|
-| `priv` / `access(self)`  | Current and inner                                   |
-| `access(contract)`       | Current, inner, and containing contract             |
-| `access(account)`        | Current, inner, and other contracts in same account |
-| `pub` / `access(all)`    | **All**                                             |
+| Access modifier    | Access scope                                        |
+|:-------------------|:----------------------------------------------------|
+| `access(self)`     | Current and inner                                   |
+| `access(contract)` | Current, inner, and containing contract             |
+| `access(account)`  | Current, inner, and other contracts in same account |
+| ``access(all)`     | **All**                                             |
 
 Declarations of structures, resources, events, and [contracts](./contracts.mdx) can only be public.
 However, even though the declarations/types are publicly visible,
@@ -112,13 +109,13 @@ access(self) let a = 1
 
 // Declare a public constant, accessible/visible in all scopes.
 //
-pub let b = 2
+access(all) let b = 2
 ```
 
 ```cadence
 // Declare a public struct, accessible/visible in all scopes.
 //
-pub struct SomeStruct {
+access(all) struct SomeStruct {
 
     // Declare a private constant field which is only readable
     // in the current and inner scopes.
@@ -127,7 +124,7 @@ pub struct SomeStruct {
 
     // Declare a public constant field which is readable in all scopes.
     //
-    pub let b: Int
+    access(all) let b: Int
 
     // Declare a private variable field which is only readable
     // and writable in the current and inner scopes.
@@ -138,16 +135,11 @@ pub struct SomeStruct {
     // so it is only writable in the current and inner scopes,
     // and readable in all scopes.
     //
-    pub var d: Int
-
-    // Declare a public variable field which is settable,
-    // so it is readable and writable in all scopes.
-    //
-    pub(set) var e: Int
+    access(all) var d: Int
 
     // Arrays and dictionaries declared without (set) cannot be
     // mutated in external scopes
-    pub let arr: [Int]
+    access(all) let arr: [Int]
 
     // The initializer is omitted for brevity.
 
@@ -160,7 +152,7 @@ pub struct SomeStruct {
 
     // Declare a public function which is callable in all scopes.
     //
-    pub fun privateTest() {
+    access(all) fun publicTest() {
         // ...
     }
 
@@ -201,14 +193,6 @@ some.d
 // Invalid: cannot set public variable field in outer scope.
 //
 some.d = 4
-
-// Valid: can read publicly settable variable field in outer scope.
-//
-some.e
-
-// Valid: can set publicly settable variable field in outer scope.
-//
-some.e = 5
 
 // Invalid: cannot mutate a public field in outer scope.
 //

--- a/docs/cadence/language/accounts.mdx
+++ b/docs/cadence/language/accounts.mdx
@@ -11,38 +11,38 @@ Every account can be accessed through two types, `PublicAccount` and `AuthAccoun
 which represents the publicly available portion of an account.
 
 ```cadence
-pub struct PublicAccount {
+access(all) struct PublicAccount {
 
     /// The address of the account.
-    pub let address: Address
+    access(all) let address: Address
 
     /// The FLOW balance of the default vault of this account.
-    pub let balance: UFix64
+    access(all) let balance: UFix64
 
     /// The FLOW balance of the default vault of this account that is available to be moved.
-    pub let availableBalance: UFix64
+    access(all) let availableBalance: UFix64
 
     /// The current amount of storage used by the account in bytes.
-    pub let storageUsed: UInt64
+    access(all) let storageUsed: UInt64
 
     /// The storage capacity of the account in bytes.
-    pub let storageCapacity: UInt64
+    access(all) let storageCapacity: UInt64
 
     /// The contracts deployed to the account.
-    pub let contracts: PublicAccount.Contracts
+    access(all) let contracts: PublicAccount.Contracts
 
     /// The keys assigned to the account.
-    pub let keys: PublicAccount.Keys
+    access(all) let keys: PublicAccount.Keys
 
     /// All public paths of this account.
-    pub let publicPaths: [PublicPath]
+    access(all) let publicPaths: [PublicPath]
 
     /// Returns the capability at the given public path.
-    pub fun getCapability<T: &Any>(_ path: PublicPath): Capability<T>
+    access(all) fun getCapability<T: &Any>(_ path: PublicPath): Capability<T>
 
     /// Returns the target path of the capability at the given public or private path,
     /// or nil if there exists no capability at the given path.
-    pub fun getLinkTarget(_ path: CapabilityPath): Path?
+    access(all) fun getLinkTarget(_ path: CapabilityPath): Path?
 
     /// Iterate over all the public paths of an account.
     /// passing each path and type in turn to the provided callback function.
@@ -55,41 +55,41 @@ pub struct PublicAccount {
     ///
     /// The order of iteration, as well as the behavior of adding or removing objects from storage during iteration,
     /// is undefined.
-    pub fun forEachPublic(_ function: fun(PublicPath, Type): Bool)
+    access(all) fun forEachPublic(_ function: fun(PublicPath, Type): Bool)
 
-    pub struct Contracts {
+    access(all) struct Contracts {
 
         /// The names of all contracts deployed in the account.
-        pub let names: [String]
+        access(all) let names: [String]
 
         /// Returns the deployed contract for the contract/contract interface with the given name in the account, if any.
         ///
         /// Returns nil if no contract/contract interface with the given name exists in the account.
-        pub fun get(name: String): DeployedContract?
+        access(all) fun get(name: String): DeployedContract?
 
         /// Returns a reference of the given type to the contract with the given name in the account, if any.
         ///
         /// Returns nil if no contract with the given name exists in the account,
         /// or if the contract does not conform to the given type.
-        pub fun borrow<T: &Any>(name: String): T?
+        access(all) fun borrow<T: &Any>(name: String): T?
     }
 
-    pub struct Keys {
+    access(all) struct Keys {
 
         /// Returns the key at the given index, if it exists, or nil otherwise.
         ///
         /// Revoked keys are always returned, but they have `isRevoked` field set to true.
-        pub fun get(keyIndex: Int): AccountKey?
+        access(all) fun get(keyIndex: Int): AccountKey?
 
         /// Iterate over all unrevoked keys in this account,
         /// passing each key in turn to the provided function.
         ///
         /// Iteration is stopped early if the function returns `false`.
         /// The order of iteration is undefined.
-        pub fun forEach(_ function: fun(AccountKey): Bool)
+        access(all) fun forEach(_ function: fun(AccountKey): Bool)
 
         /// The total number of unrevoked keys in this account.
-        pub let count: UInt64
+        access(all) let count: UInt64
     }
 }
 ```
@@ -114,40 +114,40 @@ For each signer of the transaction that signs as an authorizer, the correspondin
 to the `prepare` phase of the transaction.
 
 ```cadence
-pub struct AuthAccount {
+access(all) struct AuthAccount {
 
     /// The address of the account.
-    pub let address: Address
+    access(all) let address: Address
 
     /// The FLOW balance of the default vault of this account.
-    pub let balance: UFix64
+    access(all) let balance: UFix64
 
     /// The FLOW balance of the default vault of this account that is available to be moved.
-    pub let availableBalance: UFix64
+    access(all) let availableBalance: UFix64
 
     /// The current amount of storage used by the account in bytes.
-    pub let storageUsed: UInt64
+    access(all) let storageUsed: UInt64
 
     /// The storage capacity of the account in bytes.
-    pub let storageCapacity: UInt64
+    access(all) let storageCapacity: UInt64
 
     /// The contracts deployed to the account.
-    pub let contracts: AuthAccount.Contracts
+    access(all) let contracts: AuthAccount.Contracts
 
     /// The keys assigned to the account.
-    pub let keys: AuthAccount.Keys
+    access(all) let keys: AuthAccount.Keys
 
     /// The inbox allows bootstrapping (sending and receiving) capabilities.
-    pub let inbox: AuthAccount.Inbox
+    access(all) let inbox: AuthAccount.Inbox
 
     /// All public paths of this account.
-    pub let publicPaths: [PublicPath]
+    access(all) let publicPaths: [PublicPath]
 
     /// All private paths of this account.
-    pub let privatePaths: [PrivatePath]
+    access(all) let privatePaths: [PrivatePath]
 
     /// All storage paths of this account.
-    pub let storagePaths: [StoragePath]
+    access(all) let storagePaths: [StoragePath]
 
     // Account storage API (see the section below for documentation)
 
@@ -162,7 +162,7 @@ pub struct AuthAccount {
     /// If there is already an object stored under the given path, the program aborts.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    pub fun save<T: Storable>(_ value: T, to: StoragePath)
+    access(all) fun save<T: Storable>(_ value: T, to: StoragePath)
 
     /// Reads the type of an object from the account's storage which is stored under the given path,
     /// or nil if no object is stored under the given path.
@@ -170,7 +170,7 @@ pub struct AuthAccount {
     /// If there is an object stored, the type of the object is returned without modifying the stored object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    pub fun type(at: StoragePath): Type?
+    access(all) fun type(at: StoragePath): Type?
 
     /// Loads an object from the account's storage which is stored under the given path,
     /// or nil if no object is stored under the given path.
@@ -186,7 +186,7 @@ pub struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the loaded object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    pub fun load<T: Storable>(from: StoragePath): T?
+    access(all) fun load<T: Storable>(from: StoragePath): T?
 
     /// Returns a copy of a structure stored in account storage under the given path,
     /// without removing it from storage,
@@ -201,7 +201,7 @@ pub struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the copied structure.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    pub fun copy<T: AnyStruct>(from: StoragePath): T?
+    access(all) fun copy<T: AnyStruct>(from: StoragePath): T?
 
     /// Returns a reference to an object in storage without removing it from storage.
     ///
@@ -213,7 +213,7 @@ pub struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the borrowed object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed
-    pub fun borrow<T: &Any>(from: StoragePath): T?
+    access(all) fun borrow<T: &Any>(from: StoragePath): T?
 
     /// Returns true if the object in account storage under the given path satisfies the given type, 
     /// i.e. could be borrowed using the given type.
@@ -221,7 +221,7 @@ pub struct AuthAccount {
     /// The given type must not necessarily be exactly the same as the type of the borrowed object.
     ///
     /// The path must be a storage path, i.e., only the domain `storage` is allowed.
-    pub fun check<T: Any>(from: StoragePath): Bool
+    access(all) fun check<T: Any>(from: StoragePath): Bool
 
     /// Creates a capability at the given public or private path,
     /// which targets the given public, private, or storage path.
@@ -241,22 +241,22 @@ pub struct AuthAccount {
     ///
     /// The target value might be stored after the link is created,
     /// and the target value might be moved out after the link has been created.
-    pub fun link<T: &Any>(_ newCapabilityPath: CapabilityPath, target: Path): Capability<T>?
+    access(all) fun link<T: &Any>(_ newCapabilityPath: CapabilityPath, target: Path): Capability<T>?
 
     /// Creates a capability at the given public or private path which targets this account.
     ///
     /// Returns nil if a link for the given capability path already exists, or the newly created capability if not.
-    pub fun linkAccount(_ newCapabilityPath: PrivatePath): Capability<&AuthAccount>?
+    access(all) fun linkAccount(_ newCapabilityPath: PrivatePath): Capability<&AuthAccount>?
 
     /// Returns the capability at the given private or public path.
-    pub fun getCapability<T: &Any>(_ path: CapabilityPath): Capability<T>
+    access(all) fun getCapability<T: &Any>(_ path: CapabilityPath): Capability<T>
 
     /// Returns the target path of the capability at the given public or private path,
     /// or nil if there exists no capability at the given path.
-    pub fun getLinkTarget(_ path: CapabilityPath): Path?
+    access(all) fun getLinkTarget(_ path: CapabilityPath): Path?
 
     /// Removes the capability at the given public or private path.
-    pub fun unlink(_ path: CapabilityPath)
+    access(all) fun unlink(_ path: CapabilityPath)
 
     /// Iterate over all the public paths of an account.
     /// passing each path and type in turn to the provided callback function.
@@ -269,7 +269,7 @@ pub struct AuthAccount {
     ///
     /// The order of iteration, as well as the behavior of adding or removing objects from storage during iteration,
     /// is undefined.
-    pub fun forEachPublic(_ function: ((PublicPath, Type): Bool))
+    access(all) fun forEachPublic(_ function: ((PublicPath, Type): Bool))
 
     /// Iterate over all the private paths of an account.
     /// passing each path and type in turn to the provided callback function.
@@ -282,7 +282,7 @@ pub struct AuthAccount {
     ///
     /// The order of iteration, as well as the behavior of adding or removing objects from storage during iteration,
     /// is undefined.
-    pub fun forEachPrivate(_ function: ((PrivatePath, Type): Bool))
+    access(all) fun forEachPrivate(_ function: ((PrivatePath, Type): Bool))
 
     /// Iterate over all the stored paths of an account.
     /// passing each path and type in turn to the provided callback function.
@@ -295,12 +295,12 @@ pub struct AuthAccount {
     ///
     /// The order of iteration, as well as the behavior of adding or removing objects from storage during iteration,
     /// is undefined.
-    pub fun forEachStored(_ function: ((StoragePath, Type): Bool))
+    access(all) fun forEachStored(_ function: ((StoragePath, Type): Bool))
 
-    pub struct Contracts {
+    access(all) struct Contracts {
 
         /// The names of all contracts deployed in the account.
-        pub let names: [String]
+        access(all) let names: [String]
 
         /// Adds the given contract to the account.
         ///
@@ -316,7 +316,7 @@ pub struct AuthAccount {
         /// or if the given name does not match the name of the contract/contract interface declaration in the code.
         ///
         /// Returns the deployed contract.
-        pub fun add(
+        access(all) fun add(
             name: String,
             code: [UInt8]
         ): DeployedContract
@@ -337,33 +337,33 @@ pub struct AuthAccount {
         /// or if the given name does not match the name of the contract/contract interface declaration in the code.
         ///
         /// Returns the deployed contract for the updated contract.
-        pub fun update__experimental(name: String, code: [UInt8]): DeployedContract
+        access(all) fun update__experimental(name: String, code: [UInt8]): DeployedContract
 
         /// Returns the deployed contract for the contract/contract interface with the given name in the account, if any.
         ///
         /// Returns nil if no contract/contract interface with the given name exists in the account.
-        pub fun get(name: String): DeployedContract?
+        access(all) fun get(name: String): DeployedContract?
 
         /// Removes the contract/contract interface from the account which has the given name, if any.
         ///
         /// Returns the removed deployed contract, if any.
         ///
         /// Returns nil if no contract/contract interface with the given name exists in the account.
-        pub fun remove(name: String): DeployedContract?
+        access(all) fun remove(name: String): DeployedContract?
 
         /// Returns a reference of the given type to the contract with the given name in the account, if any.
         ///
         /// Returns nil if no contract with the given name exists in the account,
         /// or if the contract does not conform to the given type.
-        pub fun borrow<T: &Any>(name: String): T?
+        access(all) fun borrow<T: &Any>(name: String): T?
     }
 
-    pub struct Keys {
+    access(all) struct Keys {
 
         /// Adds a new key with the given hashing algorithm and a weight.
         ///
         /// Returns the added key.
-        pub fun add(
+        access(all) fun add(
             publicKey: PublicKey,
             hashAlgorithm: HashAlgorithm,
             weight: UFix64
@@ -372,36 +372,36 @@ pub struct AuthAccount {
         /// Returns the key at the given index, if it exists, or nil otherwise.
         ///
         /// Revoked keys are always returned, but they have `isRevoked` field set to true.
-        pub fun get(keyIndex: Int): AccountKey?
+        access(all) fun get(keyIndex: Int): AccountKey?
 
         /// Marks the key at the given index revoked, but does not delete it.
         ///
         /// Returns the revoked key if it exists, or nil otherwise.
-        pub fun revoke(keyIndex: Int): AccountKey?
+        access(all) fun revoke(keyIndex: Int): AccountKey?
 
         /// Iterate over all unrevoked keys in this account,
         /// passing each key in turn to the provided function.
         ///
         /// Iteration is stopped early if the function returns `false`.
         /// The order of iteration is undefined.
-        pub fun forEach(_ function: fun(AccountKey): Bool)
+        access(all) fun forEach(_ function: fun(AccountKey): Bool)
 
         /// The total number of unrevoked keys in this account.
-        pub let count: UInt64
+        access(all) let count: UInt64
     }
 
-    pub struct Inbox {
+    access(all) struct Inbox {
 
         /// Publishes a new Capability under the given name,
         /// to be claimed by the specified recipient.
-        pub fun publish(_ value: Capability, name: String, recipient: Address)
+        access(all) fun publish(_ value: Capability, name: String, recipient: Address)
 
         /// Unpublishes a Capability previously published by this account.
         ///
         /// Returns `nil` if no Capability is published under the given name.
         ///
         /// Errors if the Capability under that name does not match the provided type.
-        pub fun unpublish<T: &Any>(_ name: String): Capability<T>?
+        access(all) fun unpublish<T: &Any>(_ name: String): Capability<T>?
 
         /// Claims a Capability previously published by the specified provider.
         ///
@@ -409,7 +409,7 @@ pub struct AuthAccount {
         /// or if this account is not its intended recipient.
         ///
         /// Errors if the Capability under that name does not match the provided type.
-        pub fun claim<T: &Any>(_ name: String, provider: Address): Capability<T>?
+        access(all) fun claim<T: &Any>(_ name: String, provider: Address): Capability<T>?
     }
 }
 ```
@@ -748,9 +748,9 @@ The path must be a storage path, i.e., only the domain `storage` is allowed.
 // Declare a resource named `Counter`.
 //
 resource Counter {
-    pub var count: Int
+    access(all) var count: Int
 
-    pub init(count: Int) {
+    access(all) init(count: Int) {
         self.count = count
     }
 }
@@ -860,9 +860,9 @@ resource interface HasCount {
 // Declare a resource named `Counter` that conforms to `HasCount`
 //
 resource Counter: HasCount {
-    pub var count: Int
+    access(all) var count: Int
 
-    pub init(count: Int) {
+    access(all) init(count: Int) {
         self.count = count
     }
 }

--- a/docs/cadence/language/attachments.mdx
+++ b/docs/cadence/language/attachments.mdx
@@ -14,11 +14,11 @@ without requiring the original author of the type to plan or account for the int
 ## Declaring Attachments
 
 Attachments are declared with the `attachment` keyword, which would be declared using a new form of composite declaration:
-`pub attachment <Name> for <Type>: <Conformances> { ... }`, where the attachment functions and fields are declared in the body.
+`access(all) attachment <Name> for <Type>: <Conformances> { ... }`, where the attachment functions and fields are declared in the body.
 As such, the following would be examples of legal declarations of attachments:
 
 ```cadence
-pub attachment Foo for MyStruct {
+access(all) attachment Foo for MyStruct {
     // ...
 }
 
@@ -36,7 +36,7 @@ Note that the base type may be either a concrete composite type or an interface.
 In the former case, the attachment is only usable on values specifically of that base type,
 while in the case of an interface the attachment is usable on any type that conforms to that interface.
 
-As with other type declarations, attachments may only have a `pub` access modifier (if one is present).
+As with other type declarations, attachments may only have a `access(all)` access modifier (if one is present).
 
 The body of the attachment follows the same declaration rules as composites.
 In particular, they may have both field and function members,
@@ -55,29 +55,29 @@ Within the body of an attachment, there is also a `base` keyword available,
 which contains a reference to the attachment's base value;
 that is, the composite to which the attachment is attached.
 Its type, therefore, is a reference to the attachment's declared base type.
-So, for an attachment declared `pub attachment Foo for Bar`, the `base` field of `Foo` would have type `&Bar`.
+So, for an attachment declared `access(all) attachment Foo for Bar`, the `base` field of `Foo` would have type `&Bar`.
 
 So, for example, this would be a valid declaration of an attachment:
 
 ```
-pub resource R {
-    pub let x: Int
+access(all) resource R {
+    access(all) let x: Int
 
     init (_ x: Int) {
         self.x = x
     }
 
-    pub fun foo() { ... }
+    access(all) fun foo() { ... }
 }
 
-pub attachment A for R {
-    pub let derivedX: Int
+access(all) attachment A for R {
+    access(all) let derivedX: Int
 
     init (_ scalar: Int) {
         self.derivedX = base.x * scalar
     }
 
-    pub fun foo() {
+    access(all) fun foo() {
         base.foo()
     }
 }
@@ -86,18 +86,18 @@ pub attachment A for R {
 
 For the purposes of external mutation checks or [access control](./access-control.md),
 the attachment is considered a separate declaration from its base type.
-A developer cannot, therefore, access any `priv` fields
+A developer cannot, therefore, access any `access(self)` fields
 (or `access(contract)` fields if the base was defined in a different contract to the attachment)
 on the `base` value, nor can they mutate any array or dictionary typed fields.
 
 ```cadence
-pub resource interface SomeInterface {
-    pub let b: Bool
-    priv let i: Int
-    pub let a: [String]
+access(all) resource interface SomeInterface {
+    access(all) let b: Bool
+    access(self) let i: Int
+    access(all) let a: [String]
 }
-pub attachment SomeAttachment for SomeContract.SomeStruct {
-    pub let i: Int
+access(all) attachment SomeAttachment for SomeContract.SomeStruct {
+    access(all) let i: Int
     init(i: Int) {
         if base.b {
             self.i = base.i // cannot access `i` on the `base` value
@@ -105,7 +105,7 @@ pub attachment SomeAttachment for SomeContract.SomeStruct {
             self.i = i
         }
     }
-    pub fun foo() {
+    access(all) fun foo() {
         base.a.append("hello") // cannot mutate `a` outside of the composite where it was defined
     }
 }
@@ -113,7 +113,7 @@ pub attachment SomeAttachment for SomeContract.SomeStruct {
 
 ### Attachment Types
 
-An attachment declared with `pub attachment A for C { ... }` will have a nominal type `A`.
+An attachment declared with `access(all) attachment A for C { ... }` will have a nominal type `A`.
 
 It is important to note that attachments are not first class values in Cadence, and as such their usage is limited in certain ways.
 In particular, their types cannot appear outside of a reference type.
@@ -135,8 +135,8 @@ the `to` keyword, and an expression that evaluates to the base value for that at
 Any arguments required by the attachment's `init` function are provided in its constructor call.
 
 ```cadence
-pub resource R {}
-pub attachment A for R {
+access(all) resource R {}
+access(all) attachment A for R {
     init(x: Int) {
         //...
     }
@@ -155,9 +155,9 @@ but it is important to note that the attachment being created will not be access
 
 
 ```cadence
-pub resource interface I {}
-pub resource R: I {}
-pub attachment A for I {}
+access(all) resource interface I {}
+access(all) resource R: I {}
+access(all) attachment A for I {}
 
 // ...
 let r <- create R() // has type @R

--- a/docs/cadence/language/capability-based-access-control.md
+++ b/docs/cadence/language/capability-based-access-control.md
@@ -149,13 +149,13 @@ resource interface HasCount {
 // Declare a resource named `Counter` that conforms to `HasCount`
 //
 resource Counter: HasCount {
-    pub var count: Int
+    access(all) var count: Int
 
-    pub init(count: Int) {
+    access(all) init(count: Int) {
         self.count = count
     }
 
-    pub fun increment(by amount: Int) {
+    access(all) fun increment(by amount: Int) {
         self.count = self.count + amount
     }
 }

--- a/docs/cadence/language/composite-types.mdx
+++ b/docs/cadence/language/composite-types.mdx
@@ -57,11 +57,11 @@ and resources are declared using the `resource` keyword.
 The keyword is followed by the name.
 
 ```cadence
-pub struct SomeStruct {
+access(all) struct SomeStruct {
     // ...
 }
 
-pub resource SomeResource {
+access(all) resource SomeResource {
     // ...
 }
 ```
@@ -156,14 +156,14 @@ and the name of the field.
 //
 // Both fields are initialized through the initializer.
 //
-// The public access modifier `pub` is used in this example to allow
+// The public access modifier `access(all)` is used in this example to allow
 // the fields to be read in outer scopes. Fields can also be declared
 // private so they cannot be accessed in outer scopes.
 // Access control will be explained in a later section.
 //
-pub struct Token {
-    pub let id: Int
-    pub var balance: Int
+access(all) struct Token {
+    access(all) let id: Int
+    access(all) var balance: Int
 
     init(id: Int, balance: Int) {
         self.id = id
@@ -175,19 +175,19 @@ pub struct Token {
 Note that it is invalid to provide the initial value for a field in the field declaration.
 
 ```cadence
-pub struct StructureWithConstantField {
+access(all) struct StructureWithConstantField {
     // Invalid: It is invalid to provide an initial value in the field declaration.
     // The field must be initialized by setting the initial value in the initializer.
     //
-    pub let id: Int = 1
+    access(all) let id: Int = 1
 }
 ```
 
 The field access syntax must be used to access fields –  fields are not available as variables.
 
 ```cadence
-pub struct Token {
-    pub let id: Int
+access(all) struct Token {
+    access(all) let id: Int
 
     init(initialID: Int) {
         // Invalid: There is no variable with the name `id` available.
@@ -201,8 +201,8 @@ pub struct Token {
 The initializer is **not** automatically derived from the fields, it must be explicitly declared.
 
 ```cadence
-pub struct Token {
-    pub let id: Int
+access(all) struct Token {
+    access(all) let id: Int
 
     // Invalid: Missing initializer initializing field `id`.
 }
@@ -235,9 +235,9 @@ In an initializer, writes to `self` are considered `view` (unlike within other c
 as the value being constructed here is by definition local to the context calling the initializer. 
 
 ```cadence
-pub struct Token {
-    pub let id: Int
-    pub var balance: Int
+access(all) struct Token {
+    access(all) let id: Int
+    access(all) var balance: Int
 
     view init(id: Int, balance: Int) {
         self.id = id
@@ -256,9 +256,9 @@ that the function is called on.
 // Declare a structure named "Rectangle", which represents a rectangle
 // and has variable fields for the width and height.
 //
-pub struct Rectangle {
-    pub var width: Int
-    pub var height: Int
+access(all) struct Rectangle {
+    access(all) var width: Int
+    access(all) var height: Int
 
     init(width: Int, height: Int) {
         self.width = width
@@ -268,7 +268,7 @@ pub struct Rectangle {
     // Declare a function named "scale", which scales
     // the rectangle by the given factor.
     //
-    pub fun scale(factor: Int) {
+    access(all) fun scale(factor: Int) {
         self.width = self.width * factor
         self.height = self.height * factor
     }
@@ -336,8 +336,8 @@ Accessing a field or calling a function of a structure does not copy it.
 ```cadence
 // Declare a structure named `SomeStruct`, with a variable integer field.
 //
-pub struct SomeStruct {
-    pub var value: Int
+access(all) struct SomeStruct {
+    access(all) var value: Int
 
     init(value: Int) {
         self.value = value
@@ -386,18 +386,18 @@ of an optional composite type.
 
 ```cadence
 // Declare a struct with a field and method.
-pub struct Value {
-    pub var number: Int
+access(all) struct Value {
+    access(all) var number: Int
 
     init() {
         self.number = 2
     }
 
-    pub fun set(new: Int) {
+    access(all) fun set(new: Int) {
         self.number = new
     }
 
-    pub fun setAndReturn(new: Int): Int {
+    access(all) fun setAndReturn(new: Int): Int {
         self.number = new
         return new
     }
@@ -449,18 +449,18 @@ of an optional composite type.
 
 ```cadence
 // Declare a struct with a field and method.
-pub struct Value {
-    pub var number: Int
+access(all) struct Value {
+    access(all) var number: Int
 
     init() {
         self.number = 2
     }
 
-    pub fun set(new: Int) {
+    access(all) fun set(new: Int) {
         self.number = new
     }
 
-    pub fun setAndReturn(new: Int): Int {
+    access(all) fun setAndReturn(new: Int): Int {
         self.number = new
         return new
     }

--- a/docs/cadence/language/contract-updatability.md
+++ b/docs/cadence/language/contract-updatability.md
@@ -74,16 +74,16 @@ A field may belong to a contract, struct, resource, or interface.
   ```cadence
   // Existing contract
 
-  pub contract Foo {
-      pub var a: String
-      pub var b: Int
+  access(all) contract Foo {
+      access(all) var a: String
+      access(all) var b: Int
   }
 
 
   // Updated contract
 
-  pub contract Foo {
-      pub var a: String
+  access(all) contract Foo {
+      access(all) var a: String
   }
   ```
   - It leaves data for the removed field unused at the storage, as it is no longer accessible.
@@ -93,17 +93,17 @@ A field may belong to a contract, struct, resource, or interface.
   ```cadence
   // Existing contract
 
-  pub contract Foo {
-      pub var a: String
-      pub var b: Int
+  access(all) contract Foo {
+      access(all) var a: String
+      access(all) var b: Int
   }
 
 
   // Updated contract
 
-  pub contract Foo {
-      pub var b: Int
-      pub var a: String
+  access(all) contract Foo {
+      access(all) var b: Int
+      access(all) var a: String
   }
   ```
 
@@ -111,15 +111,15 @@ A field may belong to a contract, struct, resource, or interface.
   ```cadence
   // Existing contract
 
-  pub contract Foo {
-      pub var a: String
+  access(all) contract Foo {
+      access(all) var a: String
   }
 
 
   // Updated contract
 
-  pub contract Foo {
-      priv var a: String   // access modifier changed to 'priv'
+  access(all) contract Foo {
+      access(self) var a: String   // access modifier changed to 'access(self)'
   }
   ```
 
@@ -128,16 +128,16 @@ A field may belong to a contract, struct, resource, or interface.
   ```cadence
   // Existing contract
 
-  pub contract Foo {
-      pub var a: String
+  access(all) contract Foo {
+      access(all) var a: String
   }
 
 
   // Updated contract
 
-  pub contract Foo {
-      pub var a: String
-      pub var b: Int      // Invalid new field
+  access(all) contract Foo {
+      access(all) var a: String
+      access(all) var b: Int      // Invalid new field
   }
   ```
     - Initializer of a contract only run once, when the contract is deployed for the first time. It does not rerun
@@ -150,15 +150,15 @@ A field may belong to a contract, struct, resource, or interface.
   ```cadence
   // Existing contract
 
-  pub contract Foo {
-      pub var a: String
+  access(all) contract Foo {
+      access(all) var a: String
   }
 
 
   // Updated contract
 
-  pub contract Foo {
-      pub var a: Int      // Invalid type change
+  access(all) contract Foo {
+      access(all) var a: Int      // Invalid type change
   }
   ```
     - In an already stored contract, the field `a` would have a value of type `String`.
@@ -180,13 +180,13 @@ A field may belong to a contract, struct, resource, or interface.
   ```cadence
   // Existing struct
 
-  pub struct Foo {
+  access(all) struct Foo {
   }
 
 
   // Upated struct
 
-  pub struct Foo: T {
+  access(all) struct Foo: T {
   }
   ```
   - However, if adding a conformance also requires changing the existing structure (e.g: adding a new field that is
@@ -203,26 +203,26 @@ A field may belong to a contract, struct, resource, or interface.
   ```cadence
   // Existing struct
 
-  pub struct Foo {
+  access(all) struct Foo {
   }
 
 
   // Changed to a struct interface
 
-  pub struct interface Foo {    // Invalid type declaration change
+  access(all) struct interface Foo {    // Invalid type declaration change
   }
   ```
 - Removing an interface conformance of a struct/resource is not valid.
   ```cadence
   // Existing struct
 
-  pub struct Foo: T {
+  access(all) struct Foo: T {
   }
 
 
   // Upated struct
 
-  pub struct Foo {
+  access(all) struct Foo {
   }
   ```
 
@@ -253,17 +253,17 @@ Below sections describes the restrictions imposed on updating the members of a s
   ```cadence
   // Existing enum with `Int` raw type
 
-  pub enum Color: Int {
-    pub case RED
-    pub case BLUE
+  access(all) enum Color: Int {
+    access(all) case RED
+    access(all) case BLUE
   }
 
 
   // Updated enum with `UInt8` raw type
 
-  pub enum Color: UInt8 {    // Invalid change of raw type
-    pub case RED
-    pub case BLUE
+  access(all) enum Color: UInt8 {    // Invalid change of raw type
+    access(all) case RED
+    access(all) case BLUE
   }
   ```
   - When the enum value is stored, the raw value associated with the enum-case gets stored.
@@ -282,18 +282,18 @@ it originally was (type confusion).
   ```cadence
   // Existing enum
 
-  pub enum Color: Int {
-    pub case RED
-    pub case BLUE
+  access(all) enum Color: Int {
+    access(all) case RED
+    access(all) case BLUE
   }
 
 
   // Updated enum
 
-  pub enum Color: Int {
-    pub case RED
-    pub case BLUE
-    pub case GREEN    // valid new enum-case at the bottom
+  access(all) enum Color: Int {
+    access(all) case RED
+    access(all) case BLUE
+    access(all) case GREEN    // valid new enum-case at the bottom
   }
   ```
 #### Invalid Changes
@@ -301,35 +301,35 @@ it originally was (type confusion).
   ```cadence
   // Existing enum
 
-  pub enum Color: Int {
-    pub case RED
-    pub case BLUE
+  access(all) enum Color: Int {
+    access(all) case RED
+    access(all) case BLUE
   }
 
 
   // Updated enum
 
-  pub enum Color: Int {
-    pub case RED
-    pub case GREEN    // invalid new enum-case in the middle
-    pub case BLUE
+  access(all) enum Color: Int {
+    access(all) case RED
+    access(all) case GREEN    // invalid new enum-case in the middle
+    access(all) case BLUE
   }
   ```
 - Changing the name of an enum-case is invalid.
   ```cadence
   // Existing enum
 
-  pub enum Color: Int {
-    pub case RED
-    pub case BLUE
+  access(all) enum Color: Int {
+    access(all) case RED
+    access(all) case BLUE
   }
 
 
   // Updated enum
 
-  pub enum Color: Int {
-    pub case RED
-    pub case GREEN    // invalid change of names
+  access(all) enum Color: Int {
+    access(all) case RED
+    access(all) case GREEN    // invalid change of names
   }
   ```
   - Previously stored raw values for `Color.BLUE` now represents `Color.GREEN`. i.e: The stored values have changed
@@ -342,16 +342,16 @@ it originally was (type confusion).
   ```cadence
   // Existing enum
 
-  pub enum Color: Int {
-    pub case RED
-    pub case BLUE
+  access(all) enum Color: Int {
+    access(all) case RED
+    access(all) case BLUE
   }
 
 
   // Updated enum
 
-  pub enum Color: Int {
-    pub case RED
+  access(all) enum Color: Int {
+    access(all) case RED
 
     // invalid removal of `case BLUE`
   }
@@ -360,17 +360,17 @@ it originally was (type confusion).
   ```cadence
   // Existing enum
 
-  pub enum Color: Int {
-    pub case RED
-    pub case BLUE
+  access(all) enum Color: Int {
+    access(all) case RED
+    access(all) case BLUE
   }
 
 
   // Updated enum
 
-  pub enum Color: UInt8 {
-    pub case BLUE   // invalid change of order
-    pub case RED
+  access(all) enum Color: UInt8 {
+    access(all) case BLUE   // invalid change of order
+    access(all) case RED
   }
   ```
   - Raw value of an enum is implicit, and corresponds to the defined order.

--- a/docs/cadence/language/contracts.mdx
+++ b/docs/cadence/language/contracts.mdx
@@ -28,7 +28,7 @@ Contracts are declared using the `contract` keyword. The keyword is followed
 by the name of the contract.
 
 ```cadence
-pub contract SomeContract {
+access(all) contract SomeContract {
     // ...
 }
 ```
@@ -36,11 +36,11 @@ pub contract SomeContract {
 Contracts cannot be nested in each other.
 
 ```cadence
-pub contract Invalid {
+access(all) contract Invalid {
 
     // Invalid: Contracts cannot be nested in any other type.
     //
-    pub contract Nested {
+    access(all) contract Nested {
         // ...
     }
 }
@@ -50,16 +50,16 @@ One of the simplest forms of a contract would just be one with a state field,
 a function, and an `init` function that initializes the field:
 
 ```cadence
-pub contract HelloWorld {
+access(all) contract HelloWorld {
 
     // Declare a stored state field in HelloWorld
     //
-    pub let greeting: String
+    access(all) let greeting: String
 
     // Declare a function that can be called by anyone
     // who imports the contract
     //
-    pub fun hello(): String {
+    access(all) fun hello(): String {
         return self.greeting
     }
 
@@ -110,9 +110,9 @@ but they have to be in the contract and not another top-level definition.
 //          if they were deployed to the account contract storage and
 //          the deployment would be rejected.
 //
-pub resource Vault {}
-pub struct Hat {}
-pub fun helloWorld(): String {}
+access(all) resource Vault {}
+access(all) struct Hat {}
+access(all) fun helloWorld(): String {}
 let num: Int
 ```
 
@@ -128,13 +128,13 @@ there is no way to create this resource, so it would not be usable.
 
 ```cadence
 // Valid
-pub contract FungibleToken {
+access(all) contract FungibleToken {
 
-    pub resource interface Receiver {
+    access(all) resource interface Receiver {
 
-        pub balance: Int
+        access(all) balance: Int
 
-        pub fun deposit(from: @{Receiver}) {
+        access(all) fun deposit(from: @{Receiver}) {
             pre {
                 from.balance > 0:
                     "Deposit balance needs to be positive!"
@@ -146,10 +146,10 @@ pub contract FungibleToken {
         }
     }
 
-    pub resource Vault: Receiver {
+    access(all) resource Vault: Receiver {
 
         // keeps track of the total balance of the accounts tokens
-        pub var balance: Int
+        access(all) var balance: Int
 
         init(balance: Int) {
             self.balance = balance
@@ -157,7 +157,7 @@ pub contract FungibleToken {
 
         // withdraw subtracts amount from the vaults balance and
         // returns a vault object with the subtracted balance
-        pub fun withdraw(amount: Int): @Vault {
+        access(all) fun withdraw(amount: Int): @Vault {
             self.balance = self.balance - amount
             return <-create Vault(balance: amount)
         }
@@ -165,7 +165,7 @@ pub contract FungibleToken {
         // deposit takes a vault object as a parameter and adds
         // its balance to the balance of the Account's vault, then
         // destroys the sent vault because its balance has been consumed
-        pub fun deposit(from: @{Receiver}) {
+        access(all) fun deposit(from: @{Receiver}) {
             self.balance = self.balance + from.balance
             destroy from
         }
@@ -199,7 +199,7 @@ Imagine that these were declared in the above `FungibleToken` contract.
 
 ```cadence
 
-    pub fun createVault(initialBalance: Int): @Vault {
+    access(all) fun createVault(initialBalance: Int): @Vault {
         return <-create Vault(balance: initialBalance)
     }
 
@@ -238,15 +238,15 @@ The deployed contracts of an account can be accessed through the `contracts` obj
 Accounts store "deployed contracts", that is, the code of the contract:
 
 ```cadence
-pub struct DeployedContract {
+access(all) struct DeployedContract {
     /// The address of the account where the contract is deployed at.
-    pub let address: Address
+    access(all) let address: Address
 
     /// The name of the contract.
-    pub let name: String
+    access(all) let name: String
 
     /// The code of the contract.
-    pub let code: [UInt8]
+    access(all) let code: [UInt8]
 
     /// Returns an array of `Type` objects representing all the public type declarations in this contract
     /// (e.g. structs, resources, enums).
@@ -254,12 +254,12 @@ pub struct DeployedContract {
     /// For example, given a contract
     /// ```
     /// contract Foo {
-    ///       pub struct Bar {...}
-    ///       pub resource Qux {...}
+    ///       access(all) struct Bar {...}
+    ///       access(all) resource Qux {...}
     /// }
     /// ```
     /// then `.publicTypes()` will return an array equivalent to the expression `[Type<Bar>(), Type<Qux>()]`
-    pub fun publicTypes(): [Type]
+    access(all) fun publicTypes(): [Type]
 }
 ```
 
@@ -295,8 +295,8 @@ A new contract can be deployed to an account using the `add` function:
 For example, assuming the following contract code should be deployed:
 
 ```cadence
-pub contract Test {
-    pub let message: String
+access(all) contract Test {
+    access(all) let message: String
 
     init(message: String) {
         self.message = message
@@ -360,8 +360,8 @@ For example, assuming that a contract named `Test` is already deployed to the ac
 and it should be updated with the following contract code:
 
 ```cadence
-pub contract Test {
-    pub let message: String
+access(all) contract Test {
+    access(all) let message: String
 
     init(message: String) {
         self.message = message
@@ -470,19 +470,19 @@ interface by saying `{ContractInterfaceName}.{NestedInterfaceName}`
 // Declare a contract interface that declares an interface and a resource
 // that needs to implement that interface in the contract implementation.
 //
-pub contract interface InterfaceExample {
+access(all) contract interface InterfaceExample {
 
     // Implementations do not need to declare this
     // They refer to it as InterfaceExample.NestedInterface
     //
-    pub resource interface NestedInterface {}
+    access(all) resource interface NestedInterface {}
 
     // Implementations must declare this type
     //
-    pub resource Composite: NestedInterface {}
+    access(all) resource Composite: NestedInterface {}
 }
 
-pub contract ExampleContract: InterfaceExample {
+access(all) contract ExampleContract: InterfaceExample {
 
     // The contract doesn't need to redeclare the `NestedInterface` interface
     // because it is already declared in the contract interface
@@ -490,7 +490,7 @@ pub contract ExampleContract: InterfaceExample {
     // The resource has to refer to the resource interface using the name
     // of the contract interface to access it
     //
-    pub resource Composite: InterfaceExample.NestedInterface {
+    access(all) resource Composite: InterfaceExample.NestedInterface {
     }
 }
 ```

--- a/docs/cadence/language/core-events.md
+++ b/docs/cadence/language/core-events.md
@@ -16,7 +16,7 @@ Event name: `flow.AccountCreated`
 
 
 ```cadence
-pub event AccountCreated(address: Address)
+access(all) event AccountCreated(address: Address)
 ```
 
 | Field             | Type      | Description                              |
@@ -31,7 +31,7 @@ Event that is emitted when a key gets added to an account.
 Event name: `flow.AccountKeyAdded`
 
 ```cadence
-pub event AccountKeyAdded(
+access(all) event AccountKeyAdded(
     address: Address,
     publicKey: PublicKey
 )
@@ -50,7 +50,7 @@ Event that is emitted when a key gets removed from an account.
 Event name: `flow.AccountKeyRemoved`
 
 ```cadence
-pub event AccountKeyRemoved(
+access(all) event AccountKeyRemoved(
     address: Address,
     publicKey: PublicKey
 )
@@ -69,7 +69,7 @@ Event that is emitted when a contract gets deployed to an account.
 Event name: `flow.AccountContractAdded`
 
 ```cadence
-pub event AccountContractAdded(
+access(all) event AccountContractAdded(
     address: Address,
     codeHash: [UInt8],
     contract: String
@@ -89,7 +89,7 @@ Event that is emitted when a contract gets updated on an account.
 Event name: `flow.AccountContractUpdated`
 
 ```cadence
-pub event AccountContractUpdated(
+access(all) event AccountContractUpdated(
     address: Address,
     codeHash: [UInt8],
     contract: String
@@ -110,7 +110,7 @@ Event that is emitted when a contract gets removed from an account.
 Event name: `flow.AccountContractRemoved`
 
 ```cadence
-pub event AccountContractRemoved(
+access(all) event AccountContractRemoved(
     address: Address,
     codeHash: [UInt8],
     contract: String
@@ -130,7 +130,7 @@ Event that is emitted when a Capability is published from an account.
 Event name: `flow.InboxValuePublished`
 
 ```cadence
-pub event InboxValuePublished(provider: Address, recipient: Address, name: String, type: Type)
+access(all) event InboxValuePublished(provider: Address, recipient: Address, name: String, type: Type)
 ```
 
 | Field             | Type      | Description                                  |
@@ -151,7 +151,7 @@ Event that is emitted when a Capability is unpublished from an account.
 Event name: `flow.InboxValueUnpublished`
 
 ```cadence
-pub event InboxValueUnpublished(provider: Address, name: String)
+access(all) event InboxValueUnpublished(provider: Address, name: String)
 ```
 
 | Field           | Type      | Description                                  |
@@ -170,7 +170,7 @@ Event that is emitted when a Capability is claimed by an account.
 Event name: `flow.InboxValueClaimed`
 
 ```cadence
-pub event InboxValueClaimed(provider: Address, recipient: Address, name: String)
+access(all) event InboxValueClaimed(provider: Address, recipient: Address, name: String)
 ```
 
 | Field           | Type      | Description                                  |

--- a/docs/cadence/language/crypto.mdx
+++ b/docs/cadence/language/crypto.mdx
@@ -9,18 +9,18 @@ The built-in enum `HashAlgorithm` provides the set of hashing algorithms that
 are supported by the language natively.
 
 ```cadence
-pub enum HashAlgorithm: UInt8 {
+access(all) enum HashAlgorithm: UInt8 {
     /// SHA2_256 is SHA-2 with a 256-bit digest (also referred to as SHA256).
-    pub case SHA2_256 = 1
+    access(all) case SHA2_256 = 1
 
     /// SHA2_384 is SHA-2 with a 384-bit digest (also referred to as  SHA384).
-    pub case SHA2_384 = 2
+    access(all) case SHA2_384 = 2
 
     /// SHA3_256 is SHA-3 with a 256-bit digest.
-    pub case SHA3_256 = 3
+    access(all) case SHA3_256 = 3
 
     /// SHA3_384 is SHA-3 with a 384-bit digest.
-    pub case SHA3_384 = 4
+    access(all) case SHA3_384 = 4
 
     /// KMAC128_BLS_BLS12_381 is an instance of KECCAK Message Authentication Code (KMAC128) mac algorithm.
     /// Although this is a MAC algorithm, KMAC is included in this list as it can be used hash
@@ -29,17 +29,17 @@ pub enum HashAlgorithm: UInt8 {
     /// It is a customized version of KMAC128 that is compatible with the hashing to curve
     /// used in BLS signatures.
     /// It is the same hasher used by signatures in the internal Flow protocol.
-    pub case KMAC128_BLS_BLS12_381 = 5
+    access(all) case KMAC128_BLS_BLS12_381 = 5
 
     /// KECCAK_256 is the legacy Keccak algorithm with a 256-bits digest, as per the original submission to the NIST SHA3 competition.
     /// KECCAK_256 is different than SHA3 and is used by Ethereum.
-    pub case KECCAK_256 = 6
+    access(all) case KECCAK_256 = 6
 
     /// Returns the hash of the given data
-    pub fun hash(_ data: [UInt8]): [UInt8]
+    access(all) fun hash(_ data: [UInt8]): [UInt8]
 
     /// Returns the hash of the given data and tag
-    pub fun hashWithTag(_ data: [UInt8], tag: string): [UInt8]
+    access(all) fun hashWithTag(_ data: [UInt8], tag: string): [UInt8]
 }
 ```
 
@@ -95,17 +95,17 @@ The built-in enum `SignatureAlgorithm` provides the set of signing algorithms th
 are supported by the language natively.
 
 ```cadence
-pub enum SignatureAlgorithm: UInt8 {
+access(all) enum SignatureAlgorithm: UInt8 {
     /// ECDSA_P256 is ECDSA on the NIST P-256 curve.
-    pub case ECDSA_P256 = 1
+    access(all) case ECDSA_P256 = 1
 
     /// ECDSA_secp256k1 is ECDSA on the secp256k1 curve.
-    pub case ECDSA_secp256k1 = 2
+    access(all) case ECDSA_secp256k1 = 2
 
     /// BLS_BLS12_381 is BLS signature scheme on the BLS12-381 curve.
     /// The scheme is set-up so that signatures are in G_1 (subgroup of the curve over the prime field)
     /// while public keys are in G_2 (subgroup of the curve over the prime field extension).
-    pub case BLS_BLS12_381 = 3
+    access(all) case BLS_BLS12_381 = 3
 }
 ```
 
@@ -120,7 +120,7 @@ struct PublicKey {
 
     /// Verifies a signature under the given tag, data and public key.
     /// It uses the given hash algorithm to hash the tag and data.
-    pub fun verify(
+    access(all) fun verify(
         signature: [UInt8],
         signedData: [UInt8],
         domainSeparationTag: String,
@@ -131,7 +131,7 @@ struct PublicKey {
     /// This function is only implemented if the signature algorithm
     /// of the public key is BLS (BLS_BLS12_381).
     /// If called with any other signature algorithm, the program aborts
-    pub fun verifyPoP(_ proof: [UInt8]): Bool
+    access(all) fun verifyPoP(_ proof: [UInt8]): Bool
 }
 ```
 
@@ -328,7 +328,7 @@ For example, to verify two signatures with equal weights for some signed data:
 ```cadence
 import Crypto
 
-pub fun test main() {
+access(all) fun test main() {
     let keyList = Crypto.KeyList()
 
     let publicKeyA = PublicKey(
@@ -380,12 +380,12 @@ pub fun test main() {
 The API of the Crypto contract related to key lists is:
 
 ```cadence
-pub struct KeyListEntry {
-    pub let keyIndex: Int
-    pub let publicKey: PublicKey
-    pub let hashAlgorithm: HashAlgorithm
-    pub let weight: UFix64
-    pub let isRevoked: Bool
+access(all) struct KeyListEntry {
+    access(all) let keyIndex: Int
+    access(all) let publicKey: PublicKey
+    access(all) let hashAlgorithm: HashAlgorithm
+    access(all) let weight: UFix64
+    access(all) let isRevoked: Bool
 
     init(
         keyIndex: Int,
@@ -396,12 +396,12 @@ pub struct KeyListEntry {
     )
 }
 
-pub struct KeyList {
+access(all) struct KeyList {
 
     init()
 
     /// Adds a new key with the given weight
-    pub fun add(
+    access(all) fun add(
         _ publicKey: PublicKey,
         hashAlgorithm: HashAlgorithm,
         weight: UFix64
@@ -409,22 +409,22 @@ pub struct KeyList {
 
     /// Returns the key at the given index, if it exists.
     /// Revoked keys are always returned, but they have `isRevoked` field set to true
-    pub fun get(keyIndex: Int): KeyListEntry?
+    access(all) fun get(keyIndex: Int): KeyListEntry?
 
     /// Marks the key at the given index revoked, but does not delete it
-    pub fun revoke(keyIndex: Int)
+    access(all) fun revoke(keyIndex: Int)
 
     /// Returns true if the given signatures are valid for the given signed data
-    pub fun verify(
+    access(all) fun verify(
         signatureSet: [KeyListSignature],
         signedData: [UInt8]
     ): Bool
 }
 
-pub struct KeyListSignature {
-    pub let keyIndex: Int
-    pub let signature: [UInt8]
+access(all) struct KeyListSignature {
+    access(all) let keyIndex: Int
+    access(all) let signature: [UInt8]
 
-    pub init(keyIndex: Int, signature: [UInt8])
+    access(all) init(keyIndex: Int, signature: [UInt8])
 }
 ```

--- a/docs/cadence/language/enumerations.md
+++ b/docs/cadence/language/enumerations.md
@@ -34,10 +34,10 @@ Enum cases can be compared using the equality operators `==` and `!=`.
 // Declare an enum named `Color` which has the raw value type `UInt8`,
 // and declare three enum cases: `red`, `green`, and `blue`
 //
-pub enum Color: UInt8 {
-    pub case red
-    pub case green
-    pub case blue
+access(all) enum Color: UInt8 {
+    access(all) case red
+    access(all) case green
+    access(all) case blue
 }
 // Declare a variable which has the enum type `Color` and initialize
 // it to the enum case `blue` of the enum

--- a/docs/cadence/language/environment-information.md
+++ b/docs/cadence/language/environment-information.md
@@ -34,26 +34,26 @@ To get information about a block, the functions `getCurrentBlock` and `getBlock`
 The `Block` type contains the identifier, height, and timestamp:
 
 ```cadence
-pub struct Block {
+access(all) struct Block {
     /// The ID of the block.
     ///
     /// It is essentially the hash of the block.
     ///
-    pub let id: [UInt8; 32]
+    access(all) let id: [UInt8; 32]
 
     /// The height of the block.
     ///
     /// If the blockchain is viewed as a tree with the genesis block at the root,
     // the height of a node is the number of edges between the node and the genesis block
     ///
-    pub let height: UInt64
+    access(all) let height: UInt64
 
     /// The view of the block.
     ///
     /// It is a detail of the consensus algorithm. It is a monotonically increasing integer
     /// and counts rounds in the consensus algorithm. It is reset to zero at each spork.
     ///
-    pub let view: UInt64
+    access(all) let view: UInt64
 
     /// The timestamp of the block.
     ///
@@ -62,7 +62,7 @@ pub struct Block {
     /// NOTE: It is included by the proposer, there are no guarantees on how much the time stamp can deviate from the true time the block was published.
     /// Consider observing blocks’ status changes off-chain yourself to get a more reliable value.
     ///
-    pub let timestamp: UFix64
+    access(all) let timestamp: UFix64
 }
 ```
 

--- a/docs/cadence/language/events.md
+++ b/docs/cadence/language/events.md
@@ -28,7 +28,7 @@ Events cannot be declared globally or within resource or struct types.
 //
 event GlobalEvent(field: Int)
 
-pub contract Events {
+access(all) contract Events {
     // Event with explicit argument labels
     //
     event BarEvent(labelA fieldA: Int, labelB fieldB: Int)
@@ -46,7 +46,7 @@ pub contract Events {
 To emit an event from a program, use the `emit` statement:
 
 ```cadence
-pub contract Events {
+access(all) contract Events {
     event FooEvent(x: Int, y: Int)
 
     // Event with argument labels

--- a/docs/cadence/language/functions.mdx
+++ b/docs/cadence/language/functions.mdx
@@ -230,10 +230,10 @@ Functions can be annotated as `view` to indicate that they do not modify any ext
 A `view` annotation can be added to the beginning of a function declaration or expression like so: 
 
 ```cadence
-view pub fun foo(): Void {}
+view access(all) fun foo(): Void {}
 let x = view fun(): Void {}
-pub struct S {
-    view pub fun foo(): Void {}
+access(all) struct S {
+    view access(all) fun foo(): Void {}
     view init()
 }
 ```
@@ -591,7 +591,7 @@ or passed to functions as arguments.
 // Declare a function named `transform` which applies a function to each element
 // of an array of integers and returns a new array of the results.
 //
-pub fun transform(function: fun(Int): Int, integers: [Int]): [Int] {
+access(all) fun transform(function: fun(Int): Int, integers: [Int]): [Int] {
     var newIntegers: [Int] = []
     for integer in integers {
         newIntegers.append(function(integer))
@@ -599,7 +599,7 @@ pub fun transform(function: fun(Int): Int, integers: [Int]): [Int] {
     return newIntegers
 }
 
-pub fun double(_ integer: Int): Int {
+access(all) fun double(_ integer: Int): Int {
     return integer * 2
 }
 

--- a/docs/cadence/language/glossary.mdx
+++ b/docs/cadence/language/glossary.mdx
@@ -53,8 +53,8 @@ This emphasizes the whole type acts like a resource.
 
 ```cadence
 // Declare a resource named `SomeResource`
-pub resource SomeResource {
-    pub var value: Int
+access(all) resource SomeResource {
+    access(all) var value: Int
 
     init(value: Int) {
         self.value = value
@@ -65,7 +65,7 @@ pub resource SomeResource {
 let a: @SomeResource <- create SomeResource(value: 0)
 
 // also in functions declarations
-pub fun use(resource: @SomeResource) {
+access(all) fun use(resource: @SomeResource) {
     destroy resource
 }
 ```
@@ -187,7 +187,7 @@ If the variable is `nil`, the move succeeds.
 If it is not nil, the program aborts.
 
 ```cadence
-pub resource R {}
+access(all) resource R {}
 
 var a: @R? <- nil
 a <-! create R()

--- a/docs/cadence/language/interfaces.mdx
+++ b/docs/cadence/language/interfaces.mdx
@@ -60,9 +60,7 @@ or the field requirement may specify nothing,
 in which case the implementation may either be a variable or a constant field.
 
 Field requirements and function requirements must specify the required level of access.
-The access must be at least be public, so the `pub` keyword must be provided.
-Variable field requirements can be specified to also be publicly settable
-by using the `pub(set)` keyword.
+The access must be at least be public, so the `access(all)` keyword must be provided.
 
 Interfaces can be used in types.
 This is explained in detail in the section [Interfaces in Types](#interfaces-in-types).
@@ -72,16 +70,16 @@ For now, the syntax `{I}` can be read as the type of any value that implements t
 // Declare a resource interface for a fungible token.
 // Only resources can implement this resource interface.
 //
-pub resource interface FungibleToken {
+access(all) resource interface FungibleToken {
 
     // Require the implementing type to provide a field for the balance
-    // that is readable in all scopes (`pub`).
+    // that is readable in all scopes (`access(all)`).
     //
     // Neither the `var` keyword, nor the `let` keyword is used,
     // so the field may be implemented as either a variable
     // or as a constant field.
     //
-    pub balance: Int
+    access(all) balance: Int
 
     // Require the implementing type to provide an initializer that
     // given the initial balance, must initialize the balance field.
@@ -111,7 +109,7 @@ pub resource interface FungibleToken {
     // The type `{FungibleToken}` is the type of any resource
     // that implements the resource interface `FungibleToken`.
     //
-    pub fun withdraw(amount: Int): @{FungibleToken} {
+    access(all) fun withdraw(amount: Int): @{FungibleToken} {
         pre {
             amount > 0:
                 "the amount must be positive"
@@ -137,7 +135,7 @@ pub resource interface FungibleToken {
     // The parameter type `{FungibleToken}` is the type of any resource
     // that implements the resource interface `FungibleToken`.
     //
-    pub fun deposit(_ token: @{FungibleToken}) {
+    access(all) fun deposit(_ token: @{FungibleToken}) {
         post {
             self.balance == before(self.balance) + token.balance:
                 "the amount must be added to the balance"
@@ -184,7 +182,7 @@ in terms of name, parameter argument labels, parameter types, and the return typ
 // It has a variable field named `balance`, that can be written
 // by functions of the type, but outer scopes can only read it.
 //
-pub resource ExampleToken: FungibleToken {
+access(all) resource ExampleToken: FungibleToken {
 
     // Implement the required field `balance` for the `FungibleToken` interface.
     // The interface does not specify if the field must be variable, constant,
@@ -192,7 +190,7 @@ pub resource ExampleToken: FungibleToken {
     // but limit outer scopes to only read from the field, it is declared variable,
     // and only has public access (non-settable).
     //
-    pub var balance: Int
+    access(all) var balance: Int
 
     // Implement the required initializer for the `FungibleToken` interface:
     // accept an initial balance and initialize the `balance` field.
@@ -216,7 +214,7 @@ pub resource ExampleToken: FungibleToken {
     // NOTE: neither the precondition nor the postcondition declared
     // in the interface have to be repeated here in the implementation.
     //
-    pub fun withdraw(amount: Int): @ExampleToken {
+    access(all) fun withdraw(amount: Int): @ExampleToken {
         self.balance = self.balance - amount
         return create ExampleToken(balance: amount)
     }
@@ -237,7 +235,7 @@ pub resource ExampleToken: FungibleToken {
     // NOTE: neither the precondition nor the postcondition declared
     // in the interface have to be repeated here in the implementation.
     //
-    pub fun deposit(_ token: @{FungibleToken}) {
+    access(all) fun deposit(_ token: @{FungibleToken}) {
         if let exampleToken <- token as? ExampleToken {
             self.balance = self.balance + exampleToken.balance
             destroy exampleToken
@@ -287,26 +285,24 @@ token.withdraw(amount: 90)
 The access level for variable fields in an implementation
 may be less restrictive than the interface requires.
 For example, an interface may require a field to be
-at least public (i.e. the `pub` keyword is specified),
+at least contract-accessible (i.e. the `access(contract)` modifier is used),
 and an implementation may provide a variable field which is public,
-but also publicly settable (the `pub(set)` keyword is specified).
+(the `access(all)` modifier is used).
 
 ```cadence
-pub struct interface AnInterface {
-    // Require the implementing type to provide a publicly readable
+access(all) struct interface AnInterface {
+    // Require the implementing type to provide a contract-readable
     // field named `a` that has type `Int`. It may be a variable
     // or a constant field.
     //
-    pub a: Int
+    access(contract) a: Int
 }
 
-pub struct AnImplementation: AnInterface {
-    // Declare a publicly settable variable field named `a` that has type `Int`.
+access(all) struct AnImplementation: AnInterface {
+    // Declare a public variable field named `a` that has type `Int`.
     // This implementation satisfies the requirement for interface `AnInterface`:
-    // The field is at least publicly readable, but this implementation also
-    // allows the field to be written to in all scopes.
     //
-    pub(set) var a: Int
+    access(all) var a: Int
 
     init(a: Int) {
         self.a = a
@@ -329,18 +325,18 @@ when accessing a value of such a type.
 // Require implementing types to provide a field which returns the area,
 // and a function which scales the shape by a given factor.
 //
-pub struct interface Shape {
-    pub fun getArea(): Int
-    pub fun scale(factor: Int)
+access(all) struct interface Shape {
+    access(all) fun getArea(): Int
+    access(all) fun scale(factor: Int)
 }
 
 // Declare a structure named `Square` the implements the `Shape` interface.
 //
-pub struct Square: Shape {
+access(all) struct Square: Shape {
     // In addition to the required fields from the interface,
     // the type can also declare additional fields.
     //
-    pub var length: Int
+    access(all) var length: Int
 
     // Provided the field `area`  which is required to conform
     // to the interface `Shape`.
@@ -348,36 +344,36 @@ pub struct Square: Shape {
     // Since `area` was not declared as a constant, variable,
     // field in the interface, it can be declared.
     //
-    pub fun getArea(): Int {
+    access(all) fun getArea(): Int {
         return self.length * self.length
     }
 
-    pub init(length: Int) {
+    access(all) init(length: Int) {
         self.length = length
     }
 
     // Provided the implementation of the function `scale`
     // which is required to conform to the interface `Shape`.
     //
-    pub fun scale(factor: Int) {
+    access(all) fun scale(factor: Int) {
         self.length = self.length * factor
     }
 }
 
 // Declare a structure named `Rectangle` that also implements the `Shape` interface.
 //
-pub struct Rectangle: Shape {
-    pub var width: Int
-    pub var height: Int
+access(all) struct Rectangle: Shape {
+    access(all) var width: Int
+    access(all) var height: Int
 
     // Provided the field `area  which is required to conform
     // to the interface `Shape`.
     //
-    pub fun getArea(): Int {
+    access(all) fun getArea(): Int {
         return self.width * self.height
     }
 
-    pub init(width: Int, height: Int) {
+    access(all) init(width: Int, height: Int) {
         self.width = width
         self.height = height
     }
@@ -385,7 +381,7 @@ pub struct Rectangle: Shape {
     // Provided the implementation of the function `scale`
     // which is required to conform to the interface `Shape`.
     //
-    pub fun scale(factor: Int) {
+    access(all) fun scale(factor: Int) {
         self.width = self.width * factor
         self.height = self.height * factor
     }
@@ -528,8 +524,8 @@ For example, a resource interface may require an implementing type to provide a 
 // which must have a field named `balance`.
 //
 resource interface FungibleToken {
-    pub resource Vault {
-        pub balance: Int
+    access(all) resource Vault {
+        access(all) balance: Int
     }
 }
 
@@ -538,8 +534,8 @@ resource interface FungibleToken {
 // The nested type `Vault` must be provided to conform to the interface.
 //
 resource ExampleToken: FungibleToken {
-    pub resource Vault {
-        pub var balance: Int
+    access(all) resource Vault {
+        access(all) var balance: Int
         init(balance: Int) {
             self.balance = balance
         }
@@ -555,13 +551,13 @@ When an interface inherits from another, all the fields, functions, and types of
 available to the inheriting interface.
 
 ```cadence
-pub resource interface Receiver {
-    pub fun deposit(_ something: @AnyResource)
+access(all) resource interface Receiver {
+    access(all) fun deposit(_ something: @AnyResource)
 }
 
 // `Vault` interface inherits from `Receiver` interface.
-pub resource interface Vault: Receiver {
-    pub fun withdraw(_ amount: Int): @Vault
+access(all) resource interface Vault: Receiver {
+    access(all) fun withdraw(_ amount: Int): @Vault
 }
 ```
 
@@ -569,11 +565,11 @@ In the example above, `Vault` inherits `Receiver`. Anyone implementing the `Vaul
 implement the `Receiver` interface.
 
 ```cadence
-pub resource MyVault: Vault {
+access(all) resource MyVault: Vault {
     // Must implement all the methods coming from both `Vault` and `Receiver` interfaces.
-    pub fun deposit(_ something: @AnyResource) {}
+    access(all) fun deposit(_ something: @AnyResource) {}
 
-    pub fun withdraw(_ amount: Int): @Vault {}
+    access(all) fun withdraw(_ amount: Int): @Vault {}
 }
 ```
 
@@ -588,26 +584,26 @@ The following sections explain how these ambiguities are resolved for different 
 If two fields with identical names have identical types, then it will be valid.
 
 ```cadence
-pub resource interface Receiver {
-    pub var id: UInt64
+access(all) resource interface Receiver {
+    access(all) var id: UInt64
 }
 
-pub resource interface Vault: Receiver {
+access(all) resource interface Vault: Receiver {
     // `id` field has the same type as the `Receiver.id`. Hence this is valid.
-    pub var id: UInt64
+    access(all) var id: UInt64
 }
 ```
 
 Otherwise, interface conformance is not valid.
 
 ```cadence
-pub resource interface Receiver {
-    pub var id: Int
+access(all) resource interface Receiver {
+    access(all) var id: Int
 }
 
-pub resource interface Vault: Receiver {
+access(all) resource interface Vault: Receiver {
     // `id` field has a different type than the `Receiver.id`. Hence this is invalid.
-    pub var id: UInt64
+    access(all) var id: UInt64
 }
 ```
 
@@ -616,29 +612,29 @@ pub resource interface Vault: Receiver {
 If two functions with identical names also have identical signatures, that is valid.
 
 ```cadence
-pub resource interface Receiver {
-    pub fun deposit(_ something: @AnyResource)
+access(all) resource interface Receiver {
+    access(all) fun deposit(_ something: @AnyResource)
 }
 
-pub resource interface Vault: Receiver {
+access(all) resource interface Vault: Receiver {
     // `deposit` function has the same signature as the `Receiver.deposit`.
     // Also none of them have any default implementations.
     // Hence this is valid.
-    pub fun deposit(_ something: @AnyResource)
+    access(all) fun deposit(_ something: @AnyResource)
 }
 ```
 
 If the signatures of the two functions are different, then the interface conformance is not valid.
 
 ```cadence
-pub resource interface Receiver {
-    pub fun deposit(_ something: @AnyResource)
+access(all) resource interface Receiver {
+    access(all) fun deposit(_ something: @AnyResource)
 }
 
-pub resource interface Vault: Receiver {
+access(all) resource interface Vault: Receiver {
     // Error: `deposit` function has a different signature compared to the `Receiver.deposit`.
     // So these two cannot co-exist.
-    pub fun deposit()
+    access(all) fun deposit()
 }
 ```
 
@@ -650,17 +646,17 @@ to determine the order of the execution of the conditions.
 Given the pre/post conditions are `view` only, the order of execution would not have an impact on the conditions.
 
 ```cadence
-pub resource interface Receiver {
-    pub fun deposit(_ something: @AnyResource) {
+access(all) resource interface Receiver {
+    access(all) fun deposit(_ something: @AnyResource) {
         pre{ self.balance > 100 }
     }
 }
 
-pub resource interface Vault: Receiver {
+access(all) resource interface Vault: Receiver {
     // `deposit` function has the same signature as the `Receiver.deposit`.
     // Having pre/post condition is valid.
     // Both conditions would be executed, in a pre-determined order.
-    pub fun deposit(_ something: @AnyResource) {
+    access(all) fun deposit(_ something: @AnyResource) {
         pre{ self.balance > 50 }
     }
 }
@@ -671,13 +667,13 @@ pub resource interface Vault: Receiver {
 An interface can provide a default implementation to an inherited function.
 
 ```cadence
-pub resource interface Receiver {
-    pub fun log(_ message: String)
+access(all) resource interface Receiver {
+    access(all) fun log(_ message: String)
 }
 
-pub resource interface Vault: Receiver {
+access(all) resource interface Vault: Receiver {
     // Valid: Provides the implementation for `Receiver.log` method.
-    pub fun log(_ message: String) {
+    access(all) fun log(_ message: String) {
         log(message.append("from Vault"))
     }
 }
@@ -686,15 +682,15 @@ pub resource interface Vault: Receiver {
 However, an interface cannot override an inherited default implementation of a function.
 
 ```cadence
-pub resource interface Receiver {
-    pub fun log(_ message: String) {
+access(all) resource interface Receiver {
+    access(all) fun log(_ message: String) {
         log(message.append("from Receiver"))
     }
 }
 
-pub resource interface Vault: Receiver {
+access(all) resource interface Vault: Receiver {
     // Invalid: Cannot override the `Receiver.log` method.
-    pub fun log(_ message: String) {
+    access(all) fun log(_ message: String) {
         log(message.append("from Vault"))
     }
 }
@@ -703,39 +699,39 @@ pub resource interface Vault: Receiver {
 It is also invalid to have two or more inherited default implementations for an interface.
 
 ```cadence
-pub resource interface Receiver {
-    pub fun log(_ message: String) {
+access(all) resource interface Receiver {
+    access(all) fun log(_ message: String) {
         log(message.append("from Receiver"))
     }
 }
 
-pub resource interface Provider {
-    pub fun log(_ message: String) {
+access(all) resource interface Provider {
+    access(all) fun log(_ message: String) {
         log(message.append("from Provider"))
     }
 }
 
 // Invalid: Two default functions from two interfaces.
-pub resource interface Vault: Receiver, Provider {}
+access(all) resource interface Vault: Receiver, Provider {}
 ```
 
 Having said that, there can be situations where the same default function can be available via different
 inheritance paths.
 
 ```cadence
-pub resource interface Logger {
-    pub fun log(_ message: String) {
+access(all) resource interface Logger {
+    access(all) fun log(_ message: String) {
         log(message.append("from Logger"))
     }
 }
 
-pub resource interface Receiver: Logger {}
+access(all) resource interface Receiver: Logger {}
 
-pub resource interface Provider: Logger {}
+access(all) resource interface Provider: Logger {}
 
 // Valid: `Logger.log()` default function is visible to the `Vault` interface
 // via both `Receiver` and `Provider`.
-pub resource interface Vault: Receiver, Provider {}
+access(all) resource interface Vault: Receiver, Provider {}
 ```
 
 In the above example, `Logger.log()` default function is visible to the `Vault` interface via both `Receiver` and `Provider`. 
@@ -749,20 +745,20 @@ A more complex situation is where a default function is available via one inheri
 is available via another inheritance path.
 
 ```cadence
-pub resource interface Receiver {
-    pub fun log(_ message: String) {
+access(all) resource interface Receiver {
+    access(all) fun log(_ message: String) {
         log(message.append("from Receiver"))
     }
 }
 
-pub resource interface Provider {
-    pub fun log(_ message: String) {
+access(all) resource interface Provider {
+    access(all) fun log(_ message: String) {
         pre{ message != "" }
     }
 }
 
 // Valid: Both the default function and the condition would be available.
-pub resource interface Vault: Receiver, Provider {}
+access(all) resource interface Vault: Receiver, Provider {}
 ```
 
 In such situations, all rules applicable for default functions inheritance as well as condition inheritance
@@ -776,16 +772,16 @@ Type and event definitions would also behave similarly to the default functions.
 Inherited interfaces can override type definitions and event definitions.
 
 ```cadence
-pub contract interface Token {
-    pub struct Foo {}
+access(all) contract interface Token {
+    access(all) struct Foo {}
 }
 
-pub contract interface NonFungibleToken: Token {
-    pub struct Foo {}
+access(all) contract interface NonFungibleToken: Token {
+    access(all) struct Foo {}
 }
 
-pub contract MyToken: NonFungibleToken {
-    pub fun test() {
+access(all) contract MyToken: NonFungibleToken {
+    access(all) fun test() {
         let foo: Foo  // This will refer to the `NonFungibleToken.Foo`
     }
 }
@@ -797,32 +793,32 @@ access it using the fully qualified name. e.g: `let foo: Token.Foo`.
 However, it is not allowed to have two or more inherited type/events definitions with identical names for an interface.
 
 ```cadence
-pub contract interface Token {
-    pub struct Foo {}
+access(all) contract interface Token {
+    access(all) struct Foo {}
 }
 
-pub contract interface Collectible {
-    pub struct Foo {}
+access(all) contract interface Collectible {
+    access(all) struct Foo {}
 }
 
 // Invalid: Two type definitions with the same name from two interfaces.
-pub contract NonFungibleToken: Token, Collectible {
+access(all) contract NonFungibleToken: Token, Collectible {
 }
 ```
 Similar to default functions, there can be situations where the same type/event definition can be available
 via different inheritance paths.
 
 ```cadence
-pub contract interface Logger {
-    pub struct Foo {}
+access(all) contract interface Logger {
+    access(all) struct Foo {}
 }
 
-pub contract interface Token: Logger {}
+access(all) contract interface Token: Logger {}
 
-pub contract interface Collectible: Logger {}
+access(all) contract interface Collectible: Logger {}
 
 // Valid: `Logger.Foo` struct is visible to the `NonFungibleToken` interface via both `Token` and `Collectible`.
-pub contract interface NonFungibleToken: Token, Collectible {}
+access(all) contract interface NonFungibleToken: Token, Collectible {}
 ```
 
 In the above example, `Logger.Foo` type definition is visible to the `NonFungibleToken` interface via both `Token`
@@ -835,21 +831,21 @@ However, if at least one of the interfaces in the middle of the chain also overr
 then the code becomes invalid, as there are multiple implementations present now, which leads to ambiguity.
 
 ```cadence
-pub contract interface Logger {
-    pub struct Foo {}
+access(all) contract interface Logger {
+    access(all) struct Foo {}
 }
 
-pub contract interface Token: Logger {
-    pub struct Foo {}
+access(all) contract interface Token: Logger {
+    access(all) struct Foo {}
 }
 
-pub contract interface Collectible: Logger {}
+access(all) contract interface Collectible: Logger {}
 
 // Invalid: The default implementation of the `Foo` struct by the `Logger`
 // interface is visible to the `NonFungibleToken` via the `Collectible` interface.
 // Another implementation of `Foo` struct is visible to the `NonFungibleToken` via the `Token` interface.
 // This creates ambiguity.
-pub resource interface NonFungibleToken: Token, Provider {}
+access(all) resource interface NonFungibleToken: Token, Provider {}
 ```
 
 
@@ -873,31 +869,31 @@ This would convert to a Cadence implementation similar to:
 
 ```cadence
 struct interface A: B, C {
-    pub fun test() {
+    access(all) fun test() {
         pre { print("A") }
     }
 }
 
 struct interface B: D, E {
-    pub fun test() {
+    access(all) fun test() {
         pre { print("B") }
     }
 }
 
 struct interface C: E {
-    pub fun test() {
+    access(all) fun test() {
         pre { print("C") }
     }
 }
 
 struct interface D {
-    pub fun test() {
+    access(all) fun test() {
         pre { print("D") }
     }
 }
 
 struct interface E {
-    pub fun test() {
+    access(all) fun test() {
         pre { print("E") }
     }
 }
@@ -907,7 +903,7 @@ Any concrete type implementing interface `A` would be equivalent to implementing
 
 ```cadence
 struct Foo: A {
-    pub fun test() {
+    access(all) fun test() {
         pre { print("Foo") }
     }
 }
@@ -918,7 +914,7 @@ The linearized interface order would be: [A, B, D, E, C].
 i.e: same as having:
 ```cadence
 struct Foo: A, B, D, C, E {
-    pub fun test() {
+    access(all) fun test() {
         pre { print("Foo") }
     }
 }

--- a/docs/cadence/language/references.mdx
+++ b/docs/cadence/language/references.mdx
@@ -73,13 +73,13 @@ resource interface HasCount {
 // Declare a resource named `Counter` that conforms to `HasCount`
 //
 resource Counter: HasCount {
-    pub var count: Int
+    access(all) var count: Int
 
-    pub init(count: Int) {
+    access(all) init(count: Int) {
         self.count = count
     }
 
-    pub fun increment() {
+    access(all) fun increment() {
         self.count = self.count + 1
     }
 }

--- a/docs/cadence/language/resources.mdx
+++ b/docs/cadence/language/resources.mdx
@@ -40,8 +40,8 @@ and when it is returned from a function.
 ```cadence
 // Declare a resource named `SomeResource`, with a variable integer field.
 //
-pub resource SomeResource {
-    pub var value: Int
+access(all) resource SomeResource {
+    access(all) var value: Int
 
     init(value: Int) {
         self.value = value
@@ -69,7 +69,7 @@ b.value // equals 0
 //
 // The parameter has a resource type, so the type annotation must be prefixed with `@`.
 //
-pub fun use(resource: @SomeResource) {
+access(all) fun use(resource: @SomeResource) {
     // ...
 }
 
@@ -128,7 +128,7 @@ let someResource: @SomeResource <- create SomeResource(value: 5)
 //
 // The parameter has a resource type, so the type annotation must be prefixed with `@`.
 //
-pub fun use(resource: @SomeResource) {
+access(all) fun use(resource: @SomeResource) {
     destroy resource
 }
 
@@ -137,7 +137,7 @@ pub fun use(resource: @SomeResource) {
 // The return type is a resource type, so the type annotation must be prefixed with `@`.
 // The return statement must also use the `<-` operator to make it explicit the resource is moved.
 //
-pub fun get(): @SomeResource {
+access(all) fun get(): @SomeResource {
     let newResource <- create SomeResource()
     return <-newResource
 }
@@ -149,7 +149,7 @@ Resources **must** be used exactly once.
 // Declare a function which consumes a resource but does not use it.
 // This function is invalid, because it would cause a loss of the resource.
 //
-pub fun forgetToUse(resource: @SomeResource) {
+access(all) fun forgetToUse(resource: @SomeResource) {
     // Invalid: The resource parameter `resource` is not used, but must be.
 }
 ```
@@ -177,7 +177,7 @@ res.value
 // This function is invalid, because it does not always use the resource parameter,
 // which would cause a loss of the resource.
 //
-pub fun sometimesDestroy(resource: @SomeResource, destroyResource: Bool) {
+access(all) fun sometimesDestroy(resource: @SomeResource, destroyResource: Bool) {
     if destroyResource {
         destroy resource
     }
@@ -192,7 +192,7 @@ pub fun sometimesDestroy(resource: @SomeResource, destroyResource: Bool) {
 // This function is valid, as it always uses the resource parameter,
 // and does not cause a loss of the resource.
 //
-pub fun alwaysUse(resource: @SomeResource, destroyResource: Bool) {
+access(all) fun alwaysUse(resource: @SomeResource, destroyResource: Bool) {
     if destroyResource {
         destroy resource
     } else {
@@ -208,7 +208,7 @@ pub fun alwaysUse(resource: @SomeResource, destroyResource: Bool) {
 // This function is invalid, because it does not always use the resource parameter,
 // which would cause a loss of the resource.
 //
-pub fun returnBeforeDestroy(move: Bool) {
+access(all) fun returnBeforeDestroy(move: Bool) {
     let res <- create SomeResource(value: 1)
     if move {
         use(resource: <-res)
@@ -234,7 +234,7 @@ Instead, use a swap statement (`<->`) or shift statement (`<- target <-`)
 to replace the resource variable with another resource.
 
 ```cadence
-pub resource R {}
+access(all) resource R {}
 
 var x <- create R()
 var y <- create R()
@@ -268,7 +268,7 @@ A resource may have only one destructor.
 ```cadence
 var destructorCalled = false
 
-pub resource Resource {
+access(all) resource Resource {
 
     // Declare a destructor for the resource, which is executed
     // when the resource is destroyed.
@@ -292,7 +292,7 @@ it **must** declare a destructor,
 which **must** invalidate all resource fields, i.e. move or destroy them.
 
 ```cadence
-pub resource Child {
+access(all) resource Child {
     let name: String
 
     init(name: String)
@@ -304,7 +304,7 @@ pub resource Child {
 // The resource *must* declare a destructor
 // and the destructor *must* invalidate the resource field.
 //
-pub resource Parent {
+access(all) resource Parent {
     let name: String
     var child: @Child
 

--- a/docs/cadence/language/restricted-types.md
+++ b/docs/cadence/language/restricted-types.md
@@ -25,20 +25,20 @@ this is prevented by the static checker.
 // which has a read-only `count` field
 //
 resource interface HasCount {
-    pub let count: Int
+    access(all) let count: Int
 }
 
 // Declare a resource named `Counter`, which has a writeable `count` field,
 // and conforms to the resource interface `HasCount`
 //
-pub resource Counter: HasCount {
-    pub var count: Int
+access(all) resource Counter: HasCount {
+    access(all) var count: Int
 
     init(count: Int) {
         self.count = count
     }
 
-    pub fun increment() {
+    access(all) fun increment() {
         self.count = self.count + 1
     }
 }
@@ -77,8 +77,8 @@ unrestrictedCounter.increment()
 // Declare another resource type named `Strings`
 // which implements the resource interface `HasCount`
 //
-pub resource Strings: HasCount {
-    pub var count: Int
+access(all) resource Strings: HasCount {
+    access(all) var count: Int
     access(self) var strings: [String]
 
     init() {
@@ -86,7 +86,7 @@ pub resource Strings: HasCount {
         self.strings = []
     }
 
-    pub fun append(_ string: String) {
+    access(all) fun append(_ string: String) {
         self.strings.append(string)
         self.count = self.count + 1
     }
@@ -111,20 +111,20 @@ For example, the type `{HasCount}` is any resource that implements
 the resource interface `HasCount`.
 
 ```cadence
-pub struct interface HasID {
-    pub let id: String
+access(all) struct interface HasID {
+    access(all) let id: String
 }
 
-pub struct A: HasID {
-    pub let id: String
+access(all) struct A: HasID {
+    access(all) let id: String
 
     init(id: String) {
         self.id = id
     }
 }
 
-pub struct B: HasID {
-    pub let id: String
+access(all) struct B: HasID {
+    access(all) let id: String
 
     init(id: String) {
         self.id = id
@@ -143,7 +143,7 @@ let hasID2: {HasID} = B(id: "2")
 // The type `{HasID}` is a short-hand for `AnyStruct{HasID}`:
 // Some structure which only allows access to the functionality of interface `HasID`.
 //
-pub fun getID(_ value: {HasID}): String {
+access(all) fun getID(_ value: {HasID}): String {
     return value.id
 }
 

--- a/docs/cadence/language/run-time-types.md
+++ b/docs/cadence/language/run-time-types.md
@@ -181,21 +181,21 @@ something.isInstance(Type<String>())  // is `false`
 For example, this allows implementing a marketplace sale resource:
 
 ```cadence
-pub resource SimpleSale {
+access(all) resource SimpleSale {
 
     /// The resource for sale.
     /// Once the resource is sold, the field becomes `nil`.
     ///
-    pub var resourceForSale: @AnyResource?
+    access(all) var resourceForSale: @AnyResource?
 
     /// The price that is wanted for the purchase of the resource.
     ///
-    pub let priceForResource: UFix64
+    access(all) let priceForResource: UFix64
 
     /// The type of currency that is required for the purchase.
     ///
-    pub let requiredCurrency: Type
-    pub let paymentReceiver: Capability<&{FungibleToken.Receiver}>
+    access(all) let requiredCurrency: Type
+    access(all) let paymentReceiver: Capability<&{FungibleToken.Receiver}>
 
     /// `paymentReceiver` is the capability that will be borrowed
     /// once a valid purchase is made.
@@ -226,7 +226,7 @@ pub resource SimpleSale {
     /// If the purchase succeeds, the resource for sale is returned.
     /// If the purchase fails, the program aborts.
     ///
-    pub fun buyObject(with funds: @FungibleToken.Vault): @AnyResource {
+    access(all) fun buyObject(with funds: @FungibleToken.Vault): @AnyResource {
         pre {
             // Ensure the resource is still up for sale
             self.resourceForSale != nil: "The resource has already been sold"

--- a/docs/cadence/security-best-practices.mdx
+++ b/docs/cadence/security-best-practices.mdx
@@ -57,8 +57,8 @@ If given a less-specific type, cast to the more specific type that is expected. 
 
 ## Access Control
 
-Declaring a field as [`pub/access(all)`](./language/access-control.md) only protects from replacing the field’s value, but the value itself can still be mutated if it is mutable. Remember that containers, like dictionaries, and arrays, are mutable.
+Declaring a field as [`access(all)`](./language/access-control.md) only protects from replacing the field’s value, but the value itself can still be mutated if it is mutable. Remember that containers, like dictionaries, and arrays, are mutable.
 
 Prefer non-public access to a mutable state. That state may also be nested. For example, a child may still be mutated even if its parent exposes it through a field with non-settable access.
 
-Do not use the `pub/access(all)` modifier on fields and functions unless necessary. Prefer `priv/access(self)`, or `access(contract)` and `access(account)` when other types in the contract or account need to have access.
+Do not use the `access(all)` modifier on fields and functions unless necessary. Prefer `access(self)`, or `access(contract)` and `access(account)` when other types in the contract or account need to have access.

--- a/docs/cadence/solidity-to-cadence.mdx
+++ b/docs/cadence/solidity-to-cadence.mdx
@@ -288,7 +288,7 @@ Scripts are read-only in nature, requiring only a `main` function declaration an
 import FungibleToken from "../../contracts/FungibleToken.cdc"
 import ExampleToken from "../../contracts/ExampleToken.cdc"
 
-pub fun main(account: Address): UFix64 {
+access(all) fun main(account: Address): UFix64 {
     let acct = getAccount(account)
     let vaultRef = acct.getCapability(ExampleToken.VaultPublicPath)
         .borrow<&ExampleToken.Vault{FungibleToken.Balance}>()

--- a/docs/cadence/testing-framework.mdx
+++ b/docs/cadence/testing-framework.mdx
@@ -20,22 +20,22 @@ Both `setup` and `tearDown` functions are optional.
 // A `setup` function that will always run before the rest of the methods.
 // Can be used to initialize things that would be used across the test cases.
 // e.g: initialling a blockchain backend, initializing a contract, etc.
-pub fun setup() {
+access(all) fun setup() {
 }
 
 // Test functions start with the 'test' prefix.
-pub fun testSomething() {
+access(all) fun testSomething() {
 }
 
-pub fun testAnotherThing() {
+access(all) fun testAnotherThing() {
 }
 
-pub fun testMoreThings() {
+access(all) fun testMoreThings() {
 }
 
 // A `tearDown` function that will always run at the end of all test cases.
 // e.g: Can be used to stop the blockchain back-end used for tests, etc. or any cleanup.
-pub fun tearDown() {
+access(all) fun tearDown() {
 }
 ```
 ## Test Standard Library
@@ -80,18 +80,18 @@ fun expect(_ value: AnyStruct, _ matcher: Matcher)
 A matcher is an object that consists of a test function and associated utility functionality.
 
 ```cadence
-pub struct Matcher {
+access(all) struct Matcher {
 
-    pub let test: fun(AnyStruct): Bool
+    access(all) let test: fun(AnyStruct): Bool
 
-    pub init(test: fun(AnyStruct): Bool) {
+    access(all) init(test: fun(AnyStruct): Bool) {
         self.test = test
     }
 
     /// Combine this matcher with the given matcher.
     /// Returns a new matcher that succeeds if this and the given matcher succeed.
     ///
-    pub fun and(_ other: Matcher): Matcher {
+    access(all) fun and(_ other: Matcher): Matcher {
         return Matcher(test: fun (value: AnyStruct): Bool {
             return self.test(value) && other.test(value)
         })
@@ -100,7 +100,7 @@ pub struct Matcher {
     /// Combine this matcher with the given matcher.
     /// Returns a new matcher that succeeds if this or the given matcher succeeds.
     ///
-    pub fun or(_ other: Matcher): Matcher {
+    access(all) fun or(_ other: Matcher): Matcher {
         return Matcher(test: fun (value: AnyStruct): Bool {
             return self.test(value) || other.test(value)
         })
@@ -153,9 +153,9 @@ It imitates the behavior of a real network, for testing.
 ```cadence
 /// Blockchain emulates a real network.
 ///
-pub struct Blockchain {
+access(all) struct Blockchain {
 
-    pub let backend: AnyStruct{BlockchainBackend}
+    access(all) let backend: AnyStruct{BlockchainBackend}
 
     init(backend: AnyStruct{BlockchainBackend}) {
         self.backend = backend
@@ -164,7 +164,7 @@ pub struct Blockchain {
     /// Executes a script and returns the script return value and the status.
     /// `returnValue` field of the result will be `nil` if the script failed.
     ///
-    pub fun executeScript(_ script: String, _ arguments: [AnyStruct]): ScriptResult {
+    access(all) fun executeScript(_ script: String, _ arguments: [AnyStruct]): ScriptResult {
         return self.backend.executeScript(script, arguments)
     }
 
@@ -172,33 +172,33 @@ pub struct Blockchain {
     /// The transaction is paid by the service account.
     /// The returned account can be used to sign and authorize transactions.
     ///
-    pub fun createAccount(): Account {
+    access(all) fun createAccount(): Account {
         return self.backend.createAccount()
     }
 
     /// Add a transaction to the current block.
     ///
-    pub fun addTransaction(_ tx: Transaction) {
+    access(all) fun addTransaction(_ tx: Transaction) {
         self.backend.addTransaction(tx)
     }
 
     /// Executes the next transaction in the block, if any.
     /// Returns the result of the transaction, or nil if no transaction was scheduled.
     ///
-    pub fun executeNextTransaction(): TransactionResult? {
+    access(all) fun executeNextTransaction(): TransactionResult? {
         return self.backend.executeNextTransaction()
     }
 
     /// Commit the current block.
     /// Committing will fail if there are un-executed transactions in the block.
     ///
-    pub fun commitBlock() {
+    access(all) fun commitBlock() {
         self.backend.commitBlock()
     }
 
     /// Executes a given transaction and commits the current block.
     ///
-    pub fun executeTransaction(_ tx: Transaction): TransactionResult {
+    access(all) fun executeTransaction(_ tx: Transaction): TransactionResult {
         self.addTransaction(tx)
         let txResult = self.executeNextTransaction()!
         self.commitBlock()
@@ -207,7 +207,7 @@ pub struct Blockchain {
 
     /// Executes a given set of transactions and commits the current block.
     ///
-    pub fun executeTransactions(_ transactions: [Transaction]): [TransactionResult] {
+    access(all) fun executeTransactions(_ transactions: [Transaction]): [TransactionResult] {
         for tx in transactions {
             self.addTransaction(tx)
         }
@@ -224,7 +224,7 @@ pub struct Blockchain {
 
     /// Deploys a given contract, and initializes it with the arguments.
     ///
-    pub fun deployContract(
+    access(all) fun deployContract(
         name: String,
         code: String,
         account: Account,
@@ -245,19 +245,19 @@ The `BlockchainBackend` provides the actual functionality of the blockchain.
 ```cadence
 /// BlockchainBackend is the interface to be implemented by the backend providers.
 ///
-pub struct interface BlockchainBackend {
+access(all) struct interface BlockchainBackend {
 
-    pub fun executeScript(_ script: String, _ arguments: [AnyStruct]): ScriptResult
+    access(all) fun executeScript(_ script: String, _ arguments: [AnyStruct]): ScriptResult
 
-    pub fun createAccount(): Account
+    access(all) fun createAccount(): Account
 
-    pub fun addTransaction(_ tx: Transaction)
+    access(all) fun addTransaction(_ tx: Transaction)
 
-    pub fun executeNextTransaction(): TransactionResult?
+    access(all) fun executeNextTransaction(): TransactionResult?
 
-    pub fun commitBlock()
+    access(all) fun commitBlock()
 
-    pub fun deployContract(
+    access(all) fun deployContract(
         name: String,
         code: String,
         account: Account,
@@ -289,9 +289,9 @@ The returned account consists of the `address` of the account, and a `publicKey`
 ```cadence
 /// Account represents info about the account created on the blockchain.
 ///
-pub struct Account {
-    pub let address: Address
-    pub let publicKey: PublicKey
+access(all) struct Account {
+    access(all) let address: Address
+    access(all) let publicKey: PublicKey
 
     init(address: Address, publicKey: PublicKey) {
         self.address = address
@@ -306,7 +306,7 @@ Scripts can be run with the `executeScript` function, which returns a `ScriptRes
 The function takes script-code as the first argument, and the script-arguments as an array as the second argument.
 
 ```cadence
-let result = blockchain.executeScript("pub fun main(a: String) {}", ["hello"])
+let result = blockchain.executeScript("access(all) fun main(a: String) {}", ["hello"])
 ```
 
 The script result consists of the `status` of the script execution, and a `returnValue` if the script execution was
@@ -315,10 +315,10 @@ successful, or an `error` otherwise (see [errors](#errors) section for more deta
 ```cadence
 /// The result of a script execution.
 ///
-pub struct ScriptResult {
-    pub let status: ResultStatus
-    pub let returnValue: AnyStruct?
-    pub let error: Error?
+access(all) struct ScriptResult {
+    access(all) let status: ResultStatus
+    access(all) let returnValue: AnyStruct?
+    access(all) let error: Error?
 
     init(status: ResultStatus, returnValue: AnyStruct?, error: Error?) {
         self.status = status
@@ -336,11 +336,11 @@ a list of signers that would sign the transaction, and the transaction arguments
 ```cadence
 /// Transaction that can be submitted and executed on the blockchain.
 ///
-pub struct Transaction {
-    pub let code: String
-    pub let authorizers: [Address]
-    pub let signers: [Account]
-    pub let arguments: [AnyStruct]
+access(all) struct Transaction {
+    access(all) let code: String
+    access(all) let authorizers: [Address]
+    access(all) let signers: [Account]
+    access(all) let arguments: [AnyStruct]
 
     init(code: String, authorizers: [Address], signers: [Account], arguments: [AnyStruct]) {
         self.code = code
@@ -384,9 +384,9 @@ The result of a transaction consists of the status of the execution, and an `Err
 ```cadence
 /// The result of a transaction execution.
 ///
-pub struct TransactionResult {
-    pub let status: ResultStatus
-    pub let error: Error?
+access(all) struct TransactionResult {
+    access(all) let status: ResultStatus
+    access(all) let error: Error?
 
     init(status: ResultStatus, error: Error) {
         self.status = status
@@ -408,7 +408,7 @@ blockchain.commitBlock()
 A contract can be deployed using the `deployContract` function of the `Blockchain`.
 
 ```cadence
-let contractCode = "pub contract Foo{ pub let msg: String;   init(_ msg: String){ self.msg = msg }   pub fun sayHello(): String { return self.msg } }"
+let contractCode = "access(all) contract Foo{ access(all) let msg: String;   init(_ msg: String){ self.msg = msg }   access(all) fun sayHello(): String { return self.msg } }"
 
 let err = blockchain.deployContract(
     name: "Foo",
@@ -437,8 +437,8 @@ The `Configuration` struct consists of a mapping of import locations to their ad
 /// Configuration to be used by the blockchain.
 /// Can be used to set the address mapping.
 ///
-pub struct Configuration {
-    pub let addresses: {String: Address}
+access(all) struct Configuration {
+    access(all) let addresses: {String: Address}
 
     init(addresses: {String: Address}) {
         self.addresses = addresses
@@ -461,16 +461,16 @@ The import locations for the two contracts can be specified using the two placeh
 import FooContract from "FooContract"
 import BarContract from "BarContract"
 
-pub fun main() {
+access(all) fun main() {
     // do something
 }
 ```
 Then, before executing the script, the address mapping can be specified as follows:
 ```cadence
-pub var blockchain = Test.newEmulatorBlockchain()
-pub var accounts: [Test.Account] = []
+access(all) var blockchain = Test.newEmulatorBlockchain()
+access(all) var accounts: [Test.Account] = []
 
-pub fun setup() {
+access(all) fun setup() {
     // Create accounts in the blockchain.
 
     let acct1 = blockchain.createAccount()
@@ -500,8 +500,8 @@ Contains a message indicating why the operation failed.
 ```cadence
 // Error is returned if something has gone wrong.
 //
-pub struct Error {
-    pub let message: String
+access(all) struct Error {
+    access(all) let message: String
 
     init(_ message: String) {
         self.message = message

--- a/docs/cadence/tutorial/02-hello-world.mdx
+++ b/docs/cadence/tutorial/02-hello-world.mdx
@@ -143,12 +143,12 @@ Open the Account `0x01` tab with the file called
 ```cadence HelloWorld.cdc
 // HelloWorld.cdc
 //
-pub contract HelloWorld {
+access(all) contract HelloWorld {
 
     // Declare a public field of type String.
     //
     // All fields must be initialized in the init() function.
-    pub let greeting: String
+    access(all) let greeting: String
 
     // The init() function is required if the contract contains any fields.
     init() {
@@ -156,19 +156,19 @@ pub contract HelloWorld {
     }
 
     // Public function that returns our friendly greeting!
-    pub fun hello(): String {
+    access(all) fun hello(): String {
         return self.greeting
     }
 }
 ```
 
-The line `pub contract HelloWorld ` declares a contract that is accessible in all scopes (public).
-It's followed by `pub let greeting: String` which declares a state constant (`let`) of type `String` that is accessible in all scopes(`pub`).
+The line `access(all) contract HelloWorld ` declares a contract that is accessible in all scopes (public).
+It's followed by `access(all) let greeting: String` which declares a state constant (`let`) of type `String` that is accessible in all scopes(`access(all)`).
 
 You would have used `var` to declare a variable, which means that the value
 can be changed later on instead of remaining constant like with `let`.
 
-You can use `access(all)` and the `pub` keyword interchangeably.
+You can use `access(all)` and the `access(all)` keyword interchangeably.
 They are both examples of an access control specification that means an interface can be accessed in all scopes, but not written to in all scopes.
 For more information about the different levels of access control permitted in Cadence, refer to the [Access Control section of the language reference](../language/access-control).
 
@@ -180,7 +180,7 @@ In the above example, the initializer sets the `greeting` field to `"Hello, Worl
 The last part of our `HelloWorld` contract is a public function called `hello()`.
 This declaration returns a value of type `String`.
 Anyone who imports this contract in their transaction or script can read the public fields,
-use the public types, and call the public contract functions; i.e. the ones that have `pub` or `access(all)` specified.
+use the public types, and call the public contract functions; i.e. the ones that have `access(all)` or `access(all)` specified.
 
 Soon you'll deploy this contract to your account and run a transaction that calls its function, but first, let's look at what accounts and transactions are.
 

--- a/docs/cadence/tutorial/03-resources.mdx
+++ b/docs/cadence/tutorial/03-resources.mdx
@@ -53,8 +53,8 @@ Resources are one of Cadence's defining features.
 In Cadence, resources are a composite type like a struct or a class, but with some special rules.
 Here is an example definition of a resource:
 ```cadence
-pub resource Money {
-  pub let balance: Int
+access(all) resource Money {
+  access(all) let balance: Int
 
   init() {
     self.balance = 0
@@ -103,21 +103,21 @@ Open the Account `0x01` tab with file named `HelloWorldResource.cdc`. <br />
 </Callout>
 
 ```cadence HelloWorldResource.cdc
-pub contract HelloWorld {
+access(all) contract HelloWorld {
 
     // Declare a resource that only includes one function.
-    pub resource HelloAsset {
+    access(all) resource HelloAsset {
 
         // A transaction can call this function to get the "Hello, World!"
         // message from the resource.
-        pub fun hello(): String {
+        access(all) fun hello(): String {
             return "Hello, World!"
         }
     }
 
     // We're going to use the built-in create function to create a new instance
     // of the HelloAsset resource
-    pub fun createHelloAsset(): @HelloAsset {
+    access(all) fun createHelloAsset(): @HelloAsset {
         return <-create HelloAsset()
     }
 
@@ -135,8 +135,8 @@ Deploy this code to account `0x01` using the `Deploy` button.
 
 We start by declaring a new `HelloWorld` contract in account `0x01`, inside this new `HelloWorld` contract we:
 
-1. Declare the resource `HelloAsset` with public scope `pub`
-2. Declare the resource function `hello()` inside `HelloAsset` with public scope `pub`
+1. Declare the resource `HelloAsset` with public scope `access(all)`
+2. Declare the resource function `hello()` inside `HelloAsset` with public scope `access(all)`
 3. Declare the contract function `createHelloAsset()` which `create`s a `HelloAsset` resource
 4. The `createHelloAsset()` function uses the move operator (`<-`) to return the resource
 
@@ -154,8 +154,8 @@ Let's walk through this contract in more detail, starting with the resource.
 Resources are one of the most important things that Cadence introduces to the smart contract design experience:
 
 ```cadence
-pub resource HelloAsset {
-    pub fun hello(): String {
+access(all) resource HelloAsset {
+    access(all) fun hello(): String {
         return "Hello, World!"
     }
 }
@@ -200,7 +200,7 @@ This prevents anyone from being able to create arbitrary amounts of resource obj
 
 In this example, we declared a function that can create `HelloAsset` resources:
 ```cadence
-pub fun createHelloAsset(): @HelloAsset {
+access(all) fun createHelloAsset(): @HelloAsset {
     return <-create HelloAsset()
 }
 ```

--- a/docs/cadence/tutorial/04-capabilities.mdx
+++ b/docs/cadence/tutorial/04-capabilities.mdx
@@ -88,21 +88,21 @@ Open the Account `0x01` tab with file named `HelloWorldResource.cdc`. <br />
 </Callout>
 
 ```cadence HelloWorldResource-2.cdc
-pub contract HelloWorld {
+access(all) contract HelloWorld {
 
     // Declare a resource that only includes one function.
-    pub resource HelloAsset {
+    access(all) resource HelloAsset {
 
         // A transaction can call this function to get the "Hello, World!"
         // message from the resource.
-        pub fun hello(): String {
+        access(all) fun hello(): String {
             return "Hello, World!"
         }
     }
 
     // We're going to use the built-in create function to create a new instance
     // of the HelloAsset resource
-    pub fun createHelloAsset(): @HelloAsset {
+    access(all) fun createHelloAsset(): @HelloAsset {
         return <-create HelloAsset()
     }
 
@@ -317,7 +317,7 @@ In the next section, we look at how capabilities can expand the access a script 
 A script is a very simple transaction type in Cadence that cannot perform
 any writes to the blockchain and can only read the state of an account or contract.
 
-To execute a script, write a function called `pub fun main()`.
+To execute a script, write a function called `access(all) fun main()`.
 You can click the execute script button to run the script.
 The result of the script will be printed to the console output.
 
@@ -334,7 +334,7 @@ Open the file `Script1.cdc`.
 ```cadence Script1.cdc
 import HelloWorld from 0x01
 
-pub fun main() {
+access(all) fun main() {
 
     // Cadence code can get an account's public account object
     // by using the getAccount() built-in function.

--- a/docs/cadence/tutorial/05-non-fungible-tokens-1.mdx
+++ b/docs/cadence/tutorial/05-non-fungible-tokens-1.mdx
@@ -158,15 +158,15 @@ Open Account `0x01` to see `BasicNFT.cdc`.
 </Callout>
 
 ```cadence BasicNFT.cdc
-pub contract BasicNFT {
+access(all) contract BasicNFT {
 
     // Declare the NFT resource type
-    pub resource NFT {
+    access(all) resource NFT {
         // The unique ID that differentiates each NFT
-        pub let id: UInt64
+        access(all) let id: UInt64
 
         // String mapping to hold metadata
-        pub var metadata: {String: String}
+        access(all) var metadata: {String: String}
 
         // Initialize both fields in the init function
         init(initID: UInt64) {
@@ -176,7 +176,7 @@ pub contract BasicNFT {
     }
 
     // Function to create a new NFT
-    pub fun createNFT(id: UInt64): @NFT {
+    access(all) fun createNFT(id: UInt64): @NFT {
         return <-create NFT(initID: id)
     }
 

--- a/docs/cadence/tutorial/05-non-fungible-tokens-2.mdx
+++ b/docs/cadence/tutorial/05-non-fungible-tokens-2.mdx
@@ -82,7 +82,7 @@ This example uses a [**Dictionary**: a mutable, unordered collection of key-valu
 ```cadence
 // Keys are `Int`
 // Values are `NFT`
-pub let myNFTs: @{Int: NFT}
+access(all) let myNFTs: @{Int: NFT}
 ```
 
 In a dictionary, all keys must have the same type, and all values must have the same type.
@@ -137,22 +137,22 @@ It contains what was already in `BasicNFT.cdc` plus additional resource declarat
 //
 // Learn more about non-fungible tokens in this tutorial: https://developers.flow.com/cadence/tutorial/non-fungible-tokens-1
 
-pub contract ExampleNFT {
+access(all) contract ExampleNFT {
 
     // Declare Path constants so paths do not have to be hardcoded
     // in transactions and scripts
 
-    pub let CollectionStoragePath: StoragePath
-    pub let CollectionPublicPath: PublicPath
-    pub let MinterStoragePath: StoragePath
+    access(all) let CollectionStoragePath: StoragePath
+    access(all) let CollectionPublicPath: PublicPath
+    access(all) let MinterStoragePath: StoragePath
 
     // Tracks the unique IDs of the NFT
-    pub var idCount: UInt64
+    access(all) var idCount: UInt64
 
     // Declare the NFT resource type
-    pub resource NFT {
+    access(all) resource NFT {
         // The unique ID that differentiates each NFT
-        pub let id: UInt64
+        access(all) let id: UInt64
 
         // Initialize both fields in the init function
         init(initID: UInt64) {
@@ -164,21 +164,21 @@ pub contract ExampleNFT {
     // to create public, restricted references to their NFT Collection.
     // They would use this to publicly expose only the deposit, getIDs,
     // and idExists fields in their Collection
-    pub resource interface NFTReceiver {
+    access(all) resource interface NFTReceiver {
 
-        pub fun deposit(token: @NFT)
+        access(all) fun deposit(token: @NFT)
 
-        pub fun getIDs(): [UInt64]
+        access(all) fun getIDs(): [UInt64]
 
-        pub fun idExists(id: UInt64): Bool
+        access(all) fun idExists(id: UInt64): Bool
     }
 
     // The definition of the Collection resource that
     // holds the NFTs that a user owns
-    pub resource Collection: NFTReceiver {
+    access(all) resource Collection: NFTReceiver {
         // dictionary of NFT conforming tokens
         // NFT is a resource type with an `UInt64` ID field
-        pub var ownedNFTs: @{UInt64: NFT}
+        access(all) var ownedNFTs: @{UInt64: NFT}
 
         // Initialize the NFTs field to an empty collection
         init () {
@@ -189,7 +189,7 @@ pub contract ExampleNFT {
         //
         // Function that removes an NFT from the collection
         // and moves it to the calling context
-        pub fun withdraw(withdrawID: UInt64): @NFT {
+        access(all) fun withdraw(withdrawID: UInt64): @NFT {
             // If the NFT isn't found, the transaction panics and reverts
             let token <- self.ownedNFTs.remove(key: withdrawID)!
 
@@ -200,7 +200,7 @@ pub contract ExampleNFT {
         //
         // Function that takes a NFT as an argument and
         // adds it to the collections dictionary
-        pub fun deposit(token: @NFT) {
+        access(all) fun deposit(token: @NFT) {
             // add the new token to the dictionary with a force assignment
             // if there is already a value at that key, it will fail and revert
             self.ownedNFTs[token.id] <-! token
@@ -208,12 +208,12 @@ pub contract ExampleNFT {
 
         // idExists checks to see if a NFT
         // with the given ID exists in the collection
-        pub fun idExists(id: UInt64): Bool {
+        access(all) fun idExists(id: UInt64): Bool {
             return self.ownedNFTs[id] != nil
         }
 
         // getIDs returns an array of the IDs that are in the collection
-        pub fun getIDs(): [UInt64] {
+        access(all) fun getIDs(): [UInt64] {
             return self.ownedNFTs.keys
         }
 
@@ -223,7 +223,7 @@ pub contract ExampleNFT {
     }
 
     // creates a new empty Collection resource and returns it
-    pub fun createEmptyCollection(): @Collection {
+    access(all) fun createEmptyCollection(): @Collection {
         return <- create Collection()
     }
 
@@ -231,7 +231,7 @@ pub contract ExampleNFT {
     //
     // Function that mints a new NFT with a new ID
     // and returns it to the caller
-    pub fun mintNFT(): @NFT {
+    access(all) fun mintNFT(): @NFT {
 
         // create a new NFT
         var newNFT <- create NFT(initID: self.idCount)
@@ -317,7 +317,7 @@ of the keys of the dictionary using the built-in `keys` function.
 
 ```cadence
 // getIDs returns an array of the IDs that are in the collection
-pub fun getIDs(): [UInt64] {
+access(all) fun getIDs(): [UInt64] {
     return self.ownedNFTs.keys
 }
 ```
@@ -373,13 +373,13 @@ is only accessible by its owner. To give external accounts access to the `deposi
 the `getIDs` function, and the `idExists` function, the owner creates an interface that only includes those fields:
 
 ```cadence
-pub resource interface NFTReceiver {
+access(all) resource interface NFTReceiver {
 
-    pub fun deposit(token: @NFT)
+    access(all) fun deposit(token: @NFT)
 
-    pub fun getIDs(): [UInt64]
+    access(all) fun getIDs(): [UInt64]
 
-    pub fun idExists(id: UInt64): Bool
+    access(all) fun idExists(id: UInt64): Bool
 }
 ```
 
@@ -424,7 +424,7 @@ Open the script file named `Print 0x01 NFTs`.
 import ExampleNFT from 0x01
 
 // Print the NFTs owned by account 0x01.
-pub fun main() {
+access(all) fun main() {
     // Get the public account object for account 0x01
     let nftOwner = getAccount(0x01)
 
@@ -519,7 +519,7 @@ This prints a list of the NFTs that account `0x01` owns.
 import ExampleNFT from 0x01
 
 // Print the NFTs owned by account 0x01.
-pub fun main() {
+access(all) fun main() {
     // Get the public account object for account 0x01
     let nftOwner = getAccount(0x01)
 
@@ -642,7 +642,7 @@ Execute the script `Print all NFTs` to see the tokens in each account:
 import ExampleNFT from 0x01
 
 // Print the NFTs owned by accounts 0x01 and 0x02.
-pub fun main() {
+access(all) fun main() {
 
     // Get both public account objects
     let account1 = getAccount(0x01)

--- a/docs/cadence/tutorial/06-fungible-tokens.mdx
+++ b/docs/cadence/tutorial/06-fungible-tokens.mdx
@@ -46,7 +46,7 @@ contract LedgerToken {
 
     // Transfer tokens from one user to the other
     // by updating their balances in the central ledger
-    pub fun transfer(from: Address, to: Address, amount: UFix64) {
+    access(all) fun transfer(from: Address, to: Address, amount: UFix64) {
         balances[from] = balances[from] - amount
         balances[to] = balances[to] + amount
     }
@@ -194,23 +194,23 @@ It is important to remember that each account stores only a copy of the `Vault` 
 The `ExampleToken` contract only needs to be stored in the initial account that manages the token definitions.
 
 ```cadence Token.cdc
-pub resource Vault: Provider, Receiver {
+access(all) resource Vault: Provider, Receiver {
 
     // Balance of a user's Vault
     // we use unsigned fixed point numbers for balances
     // because they can represent decimals and do not allow negative values
-    pub var balance: UFix64
+    access(all) var balance: UFix64
 
     init(balance: UFix64) {
         self.balance = balance
     }
 
-    pub fun withdraw(amount: UFix64): @Vault {
+    access(all) fun withdraw(amount: UFix64): @Vault {
         self.balance = self.balance - amount
         return <-create Vault(balance: amount)
     }
 
-    pub fun deposit(from: @Vault) {
+    access(all) fun deposit(from: @Vault) {
         self.balance = self.balance + from.balance
         destroy from
     }
@@ -229,7 +229,7 @@ The language requires that the initialization function `init`, which is only run
 // Balance of a user's Vault
 // we use unsigned fixed-point integers for balances because they do not require the
 // concept of a negative number and allow for more clear precision
-pub var balance: UFix64
+access(all) var balance: UFix64
 
 init(balance: UFix64) {
     self.balance = balance
@@ -244,7 +244,7 @@ the balance field is no longer initialized.
 Then, the deposit function is available for any account to transfer tokens to.
 
 ```cadence
-pub fun deposit(from: @Vault) {
+access(all) fun deposit(from: @Vault) {
     self.balance = self.balance + from.balance
     destroy from
 }
@@ -263,7 +263,7 @@ When interacting with resources, you use the `@` symbol to specify the type, and
 when moving the resource, such as assigning the resource, when passing it as an argument to a function, or when returning it from a function.
 
 ```cadence
-pub fun withdraw(amount: UInt64): @Vault {
+access(all) fun withdraw(amount: UInt64): @Vault {
 ```
 
 This `@` symbol is required when specifying a resource **type** for a field, an argument, or a return value.
@@ -332,7 +332,7 @@ open and should see the code below.
 // This is a basic implementation of a Fungible Token and is NOT meant to be used in production
 // See the Flow Fungible Token standard for real examples: https://github.com/onflow/flow-ft
 
-pub contract BasicToken {
+access(all) contract BasicToken {
 
     // Vault
     //
@@ -346,10 +346,10 @@ pub contract BasicToken {
     // out of thin air. A special Minter resource or constructor function needs to be defined to mint
     // new tokens.
     //
-    pub resource Vault {
+    access(all) resource Vault {
 
 		// keeps track of the total balance of the account's tokens
-        pub var balance: UFix64
+        access(all) var balance: UFix64
 
         // initialize the balance at resource creation time
         init(balance: UFix64) {
@@ -366,7 +366,7 @@ pub contract BasicToken {
         // created Vault to the context that called so it can be deposited
         // elsewhere.
         //
-        pub fun withdraw(amount: UFix64): @Vault {
+        access(all) fun withdraw(amount: UFix64): @Vault {
             self.balance = self.balance - amount
             return <-create Vault(balance: amount)
         }
@@ -379,7 +379,7 @@ pub contract BasicToken {
         // It is allowed to destroy the sent Vault because the Vault
         // was a temporary holder of the tokens. The Vault's balance has
         // been consumed and therefore can be destroyed.
-        pub fun deposit(from: @Vault) {
+        access(all) fun deposit(from: @Vault) {
             self.balance = self.balance + from.balance
             destroy from
         }
@@ -392,7 +392,7 @@ pub contract BasicToken {
     // and store the returned Vault in their storage in order to allow their
     // account to be able to receive deposits of this token type.
     //
-    pub fun createVault(): @Vault {
+    access(all) fun createVault(): @Vault {
         return <-create Vault(balance: 30.0)
     }
 
@@ -556,8 +556,8 @@ Here is an example of how interfaces for the `Vault` resource we defined above w
 // Interface that enforces the requirements for withdrawing
 // tokens from the implementing type
 //
-pub resource interface Provider {
-    pub fun withdraw(amount: UFix64): @Vault {
+access(all) resource interface Provider {
+    access(all) fun withdraw(amount: UFix64): @Vault {
         post {
             result.balance == amount:
                 "Withdrawal amount must be the same as the balance of the withdrawn Vault"
@@ -567,19 +567,19 @@ pub resource interface Provider {
 // Interface that enforces the requirements for depositing
 // tokens into the implementing type
 //
-pub resource interface Receiver {
+access(all) resource interface Receiver {
 
     // There aren't any meaningful requirements for only a deposit function
     // but this still shows that the deposit function is required in an implementation.
-    pub fun deposit(from: @Vault)
+    access(all) fun deposit(from: @Vault)
 }
 
 // Balance
 //
 // Interface that specifies a public `balance` field for the vault
 //
-pub resource interface Balance {
-    pub var balance: UFix64
+access(all) resource interface Balance {
+    access(all) var balance: UFix64
 }
 ```
 
@@ -589,7 +589,7 @@ and that the function arguments, fields of the resource, and any return value ar
 These interfaces can be stored on-chain and imported into other contracts or resources
 so that these requirements are enforced by an immutable source of truth that is not susceptible to human error.
 
-You can also see that functions and fields have the `pub` keyword next to them.
+You can also see that functions and fields have the `access(all)` keyword next to them.
 We have explicitly defined these fields as public because all fields and functions in Cadence are private by default,
 meaning that the local scope can only access them. Users have to make parts of their owned types explicitly public.
 This helps prevent types from having unintentionally public code.
@@ -662,7 +662,7 @@ We already use this pattern in the `VaultMinter` resource in the `mintTokens` fu
 // using their `Receiver` capability.
 // We say `&AnyResource{Receiver}` to say that the recipient can be any resource
 // as long as it implements the ExampleToken.Receiver interface
-pub fun mintTokens(amount: UFix64, recipient: Capability<&AnyResource{Receiver}>) {
+access(all) fun mintTokens(amount: UFix64, recipient: Capability<&AnyResource{Receiver}>) {
     let recipientRef = recipient.borrow()
         ?? panic("Could not borrow a receiver reference to the vault")
 
@@ -978,7 +978,7 @@ Open the script named `Get Balances` in the scripts pane.
 import FungibleToken from 0x02
 
 // This script reads the Vault balances of two accounts.
-pub fun main() {
+access(all) fun main() {
     // Get the accounts' public account objects
     let acct2 = getAccount(0x02)
     let acct3 = getAccount(0x03)

--- a/docs/cadence/tutorial/07-marketplace-setup.mdx
+++ b/docs/cadence/tutorial/07-marketplace-setup.mdx
@@ -177,7 +177,7 @@ import ExampleNFT from 0x02
 //
 // Account 0x01: Vault Balance = 40, NFT.id = 1
 // Account 0x02: Vault Balance = 20, No NFTs
-pub fun main() {
+access(all) fun main() {
     // Get the accounts' public account objects
     let acct1 = getAccount(0x01)
     let acct2 = getAccount(0x02)

--- a/docs/cadence/tutorial/08-marketplace-compose.mdx
+++ b/docs/cadence/tutorial/08-marketplace-compose.mdx
@@ -110,7 +110,7 @@ import ExampleNFT from 0x02
 //
 // Account 0x01: Vault Balance = 40, NFT.id = 1
 // Account 0x02: Vault Balance = 20, No NFTs
-pub fun main() {
+access(all) fun main() {
     // Get the accounts' public account objects
     let acct1 = getAccount(0x01)
     let acct2 = getAccount(0x02)
@@ -219,27 +219,27 @@ import ExampleNFT from 0x02
 //
 // https://github.com/onflow/nft-storefront
 
-pub contract ExampleMarketplace {
+access(all) contract ExampleMarketplace {
 
     // Event that is emitted when a new NFT is put up for sale
-    pub event ForSale(id: UInt64, price: UFix64, owner: Address?)
+    access(all) event ForSale(id: UInt64, price: UFix64, owner: Address?)
 
     // Event that is emitted when the price of an NFT changes
-    pub event PriceChanged(id: UInt64, newPrice: UFix64, owner: Address?)
+    access(all) event PriceChanged(id: UInt64, newPrice: UFix64, owner: Address?)
 
     // Event that is emitted when a token is purchased
-    pub event TokenPurchased(id: UInt64, price: UFix64, seller: Address?, buyer: Address?)
+    access(all) event TokenPurchased(id: UInt64, price: UFix64, seller: Address?, buyer: Address?)
 
     // Event that is emitted when a seller withdraws their NFT from the sale
-    pub event SaleCanceled(id: UInt64, seller: Address?)
+    access(all) event SaleCanceled(id: UInt64, seller: Address?)
 
     // Interface that users will publish for their Sale collection
     // that only exposes the methods that are supposed to be public
     //
-    pub resource interface SalePublic {
-        pub fun purchase(tokenID: UInt64, recipient: Capability<&AnyResource{ExampleNFT.NFTReceiver}>, buyTokens: @ExampleToken.Vault)
-        pub fun idPrice(tokenID: UInt64): UFix64?
-        pub fun getIDs(): [UInt64]
+    access(all) resource interface SalePublic {
+        access(all) fun purchase(tokenID: UInt64, recipient: Capability<&AnyResource{ExampleNFT.NFTReceiver}>, buyTokens: @ExampleToken.Vault)
+        access(all) fun idPrice(tokenID: UInt64): UFix64?
+        access(all) fun getIDs(): [UInt64]
     }
 
     // SaleCollection
@@ -247,7 +247,7 @@ pub contract ExampleMarketplace {
     // NFT Collection object that allows a user to put their NFT up for sale
     // where others can send fungible tokens to purchase it
     //
-    pub resource SaleCollection: SalePublic {
+    access(all) resource SaleCollection: SalePublic {
 
         /// A capability for the owner's collection
         access(self) var ownerCollection: Capability<&ExampleNFT.Collection>
@@ -278,7 +278,7 @@ pub contract ExampleMarketplace {
         }
 
         // cancelSale gives the owner the opportunity to cancel a sale in the collection
-        pub fun cancelSale(tokenID: UInt64) {
+        access(all) fun cancelSale(tokenID: UInt64) {
             // remove the price
             self.prices.remove(key: tokenID)
             self.prices[tokenID] = nil
@@ -287,7 +287,7 @@ pub contract ExampleMarketplace {
         }
 
         // listForSale lists an NFT for sale in this collection
-        pub fun listForSale(tokenID: UInt64, price: UFix64) {
+        access(all) fun listForSale(tokenID: UInt64, price: UFix64) {
             pre {
                 self.ownerCollection.borrow()!.idExists(id: tokenID):
                     "NFT to be listed does not exist in the owner's collection"
@@ -299,14 +299,14 @@ pub contract ExampleMarketplace {
         }
 
         // changePrice changes the price of a token that is currently for sale
-        pub fun changePrice(tokenID: UInt64, newPrice: UFix64) {
+        access(all) fun changePrice(tokenID: UInt64, newPrice: UFix64) {
             self.prices[tokenID] = newPrice
 
             emit PriceChanged(id: tokenID, newPrice: newPrice, owner: self.owner?.address)
         }
 
         // purchase lets a user send tokens to purchase an NFT that is for sale
-        pub fun purchase(tokenID: UInt64, recipient: Capability<&AnyResource{ExampleNFT.NFTReceiver}>, buyTokens: @ExampleToken.Vault) {
+        access(all) fun purchase(tokenID: UInt64, recipient: Capability<&AnyResource{ExampleNFT.NFTReceiver}>, buyTokens: @ExampleToken.Vault) {
             pre {
                 self.prices[tokenID] != nil:
                     "No token matching this ID for sale!"
@@ -338,18 +338,18 @@ pub contract ExampleMarketplace {
         }
 
         // idPrice returns the price of a specific token in the sale
-        pub fun idPrice(tokenID: UInt64): UFix64? {
+        access(all) fun idPrice(tokenID: UInt64): UFix64? {
             return self.prices[tokenID]
         }
 
         // getIDs returns an array of token IDs that are for sale
-        pub fun getIDs(): [UInt64] {
+        access(all) fun getIDs(): [UInt64] {
             return self.prices.keys
         }
     }
 
     // createCollection returns a new collection resource to the caller
-    pub fun createSaleCollection(ownerCollection: Capability<&ExampleNFT.Collection>,
+    access(all) fun createSaleCollection(ownerCollection: Capability<&ExampleNFT.Collection>,
                                  ownerVault: Capability<&AnyResource{ExampleToken.Receiver}>): @SaleCollection {
         return <- create SaleCollection(ownerCollection: ownerCollection, ownerVault: ownerVault)
     }
@@ -365,7 +365,7 @@ that was explained in [Non-Fungible Tokens](./05-non-fungible-tokens-1.mdx), wit
   Then, another user can call the `purchase` method, sending their `ExampleToken.Vault` that contains the currency they are using to make the purchase.
   The buyer also includes a capability to their NFT `ExampleNFT.Collection` so that the purchased token
   can be immediately deposited into their collection when the purchase is made.
-- This marketplace contract stores a capability: `pub let ownerVault: Capability<&AnyResource{FungibleToken.Receiver}>`.
+- This marketplace contract stores a capability: `access(all) let ownerVault: Capability<&AnyResource{FungibleToken.Receiver}>`.
   The owner of the sale saves a capability to their Fungible Token `Receiver` within the sale.
   This allows the sale resource to be able to immediately deposit the currency that was used to buy the NFT
   into the owners `Vault` when a purchase is made.
@@ -374,16 +374,16 @@ that was explained in [Non-Fungible Tokens](./05-non-fungible-tokens-1.mdx), wit
 
 ```cadence
     // Event that is emitted when a new NFT is put up for sale
-    pub event ForSale(id: UInt64, price: UFix64, owner: Address?)
+    access(all) event ForSale(id: UInt64, price: UFix64, owner: Address?)
 
     // Event that is emitted when the price of an NFT changes
-    pub event PriceChanged(id: UInt64, newPrice: UFix64, owner: Address?)
+    access(all) event PriceChanged(id: UInt64, newPrice: UFix64, owner: Address?)
 
     // Event that is emitted when a token is purchased
-    pub event TokenPurchased(id: UInt64, price: UFix64, seller: Address?, buyer: Address?)
+    access(all) event TokenPurchased(id: UInt64, price: UFix64, seller: Address?, buyer: Address?)
 
     // Event that is emitted when a seller withdraws their NFT from the sale
-    pub event SaleCanceled(id: UInt64, seller: Address?)
+    access(all) event SaleCanceled(id: UInt64, seller: Address?)
 ```
 
 This contract has a few new features and concepts that are important to cover:
@@ -401,7 +401,7 @@ when getting information about their users' accounts or generating analytics.
 Events are declared by indicating [the access level](../language/access-control), `event`,
 and the name and parameters of the event, like a function declaration:
 ```cadence
-pub event ForSale(id: UInt64, price: UFix64, owner: Address?)
+access(all) event ForSale(id: UInt64, price: UFix64, owner: Address?)
 ```
 
 Events cannot modify state at all; they indicate when important actions happen in the smart contract.
@@ -489,7 +489,7 @@ One last piece to consider about capabilities is the decision about when to use 
 This tutorial used to have the `SaleCollection` directly store the NFTs that were for sale, like so:
 
 ```cadence
-pub resource SaleCollection: SalePublic {
+access(all) resource SaleCollection: SalePublic {
 
     /// Dictionary of NFT objects for sale
     /// Maps ID to NFT resource object
@@ -585,7 +585,7 @@ import ExampleNFT from 0x02
 import ExampleMarketplace from 0x03
 
 // This script prints the NFTs that account 0x01 has for sale.
-pub fun main() {
+access(all) fun main() {
     // Get the public account object for account 0x01
     let account1 = getAccount(0x01)
 
@@ -713,7 +713,7 @@ import ExampleMarketplace from 0x03
 //
 // Account 1: Vault balance = 50, No NFTs
 // Account 2: Vault balance = 10, NFT ID=1
-pub fun main() {
+access(all) fun main() {
     // Get the accounts' public account objects
     let acct1 = getAccount(0x01)
     let acct2 = getAccount(0x02)
@@ -806,14 +806,14 @@ If we wanted to build a central marketplace on-chain, we could use a contract th
 ```cadence CentralMarketplace.cdc
 // Marketplace would be the central contract where people can post their sale
 // references so that anyone can access them
-pub contract Marketplace {
+access(all) contract Marketplace {
     // Data structure to store active sales
-    pub var tokensForSale: {Address: Capability<&SaleCollection>)}
+    access(all) var tokensForSale: {Address: Capability<&SaleCollection>)}
 
     // listSaleCollection lists a users sale reference in the array
     // and returns the index of the sale so that users can know
     // how to remove it from the marketplace
-    pub fun listSaleCollection(collection: Capability<&SaleCollection>) {
+    access(all) fun listSaleCollection(collection: Capability<&SaleCollection>) {
         let saleRef = collection.borrow()
             ?? panic("Invalid sale collection capability")
 
@@ -822,7 +822,7 @@ pub contract Marketplace {
 
     // removeSaleCollection removes a user's sale from the array
     // of sale references
-    pub fun removeSaleCollection(owner: Address) {
+    access(all) fun removeSaleCollection(owner: Address) {
         self.tokensForSale[owner] = nil
     }
 

--- a/docs/cadence/tutorial/09-voting.mdx
+++ b/docs/cadence/tutorial/09-voting.mdx
@@ -86,25 +86,25 @@ The deployed contract should have the following contents:
 *
 */
 
-pub contract ApprovalVoting {
+access(all) contract ApprovalVoting {
 
     //list of proposals to be approved
-    pub var proposals: [String]
+    access(all) var proposals: [String]
 
     // number of votes per proposal
-    pub let votes: {Int: Int}
+    access(all) let votes: {Int: Int}
 
     // This is the resource that is issued to users.
     // When a user gets a Ballot object, they call the `vote` function
     // to include their votes, and then cast it in the smart contract
     // using the `cast` function to have their vote included in the polling
-    pub resource Ballot {
+    access(all) resource Ballot {
 
         // array of all the proposals
-        pub let proposals: [String]
+        access(all) let proposals: [String]
 
         // corresponds to an array index in proposals after a vote
-        pub var choices: {Int: Bool}
+        access(all) var choices: {Int: Bool}
 
         init() {
             self.proposals = ApprovalVoting.proposals
@@ -120,7 +120,7 @@ pub contract ApprovalVoting {
 
         // modifies the ballot
         // to indicate which proposals it is voting for
-        pub fun vote(proposal: Int) {
+        access(all) fun vote(proposal: Int) {
             pre {
                 self.proposals[proposal] != nil: "Cannot vote for a proposal that doesn't exist"
             }
@@ -130,10 +130,10 @@ pub contract ApprovalVoting {
 
     // Resource that the Administrator of the vote controls to
     // initialize the proposals and to pass out ballot resources to voters
-    pub resource Administrator {
+    access(all) resource Administrator {
 
         // function to initialize all the proposals for the voting
-        pub fun initializeProposals(_ proposals: [String]) {
+        access(all) fun initializeProposals(_ proposals: [String]) {
             pre {
                 ApprovalVoting.proposals.length == 0: "Proposals can only be initialized once"
                 proposals.length > 0: "Cannot initialize with no proposals"
@@ -150,14 +150,14 @@ pub contract ApprovalVoting {
 
         // The admin calls this function to create a new Ballot
         // that can be transferred to another user
-        pub fun issueBallot(): @Ballot {
+        access(all) fun issueBallot(): @Ballot {
             return <-create Ballot()
         }
     }
 
     // A user moves their ballot to this function in the contract where
     // its votes are tallied and the ballot is destroyed
-    pub fun cast(ballot: @Ballot) {
+    access(all) fun cast(ballot: @Ballot) {
         var index = 0
         // look through the ballot
         while index < self.proposals.length {
@@ -187,7 +187,7 @@ This contract implements a simple voting mechanism where an `Administrator` can 
 
 ```cadence
 // function to initialize all the proposals for the voting
-pub fun initializeProposals(_ proposals: [String]) {
+access(all) fun initializeProposals(_ proposals: [String]) {
     pre {
         ApprovalVoting.proposals.length == 0: "Proposals can only be initialized once"
         proposals.length > 0: "Cannot initialize with no proposals"
@@ -206,7 +206,7 @@ pub fun initializeProposals(_ proposals: [String]) {
 Then they can give `Ballot` resources to other accounts. The other accounts can record their votes on their `Ballot` resource by calling the `vote` function.
 
 ```cadence
-pub fun vote(proposal: Int) {
+access(all) fun vote(proposal: Int) {
     pre {
         self.proposals[proposal] != nil: "Cannot vote for a proposal that doesn't exist"
     }
@@ -219,7 +219,7 @@ After a user has voted, they submit their vote to the central smart contract by 
 ```cadence
 // A user moves their ballot to this function in the contract where
 // its votes are tallied and the ballot is destroyed
-pub fun cast(ballot: @Ballot) {
+access(all) fun cast(ballot: @Ballot) {
     var index = 0
     // look through the ballot
     while index < self.proposals.length {
@@ -397,7 +397,7 @@ import ApprovalVoting from 0x01
 // This script allows anyone to read the tallied votes for each proposal
 //
 
-pub fun main() {
+access(all) fun main() {
 
     // Access the public fields of the contract to log
     // the proposal names and vote counts

--- a/docs/cadence/tutorial/10-resources-compose.mdx
+++ b/docs/cadence/tutorial/10-resources-compose.mdx
@@ -92,12 +92,12 @@ The deployed contract should have the following contents:
 // support even more powerful versions of this.
 //
 
-pub contract KittyVerse {
+access(all) contract KittyVerse {
 
     // KittyHat is a special resource type that represents a hat
-    pub resource KittyHat {
-        pub let id: Int
-        pub let name: String
+    access(all) resource KittyHat {
+        access(all) let id: Int
+        access(all) let name: String
 
         init(id: Int, name: String) {
             self.id = id
@@ -105,7 +105,7 @@ pub contract KittyVerse {
         }
 
         // An example of a function someone might put in their hat resource
-        pub fun tipHat(): String {
+        access(all) fun tipHat(): String {
             if self.name == "Cowboy Hat" {
                 return "Howdy Y'all"
             } else if self.name == "Top Hat" {
@@ -117,35 +117,35 @@ pub contract KittyVerse {
     }
 
     // Create a new hat
-    pub fun createHat(id: Int, name: String): @KittyHat {
+    access(all) fun createHat(id: Int, name: String): @KittyHat {
         return <-create KittyHat(id: id, name: name)
     }
 
-    pub resource Kitty {
+    access(all) resource Kitty {
 
-        pub let id: Int
+        access(all) let id: Int
 
         // place where the Kitty hats are stored
-        pub var items: @{String: KittyHat}
+        access(all) var items: @{String: KittyHat}
 
         init(newID: Int) {
             self.id = newID
             self.items <- {}
         }
 
-        pub fun getKittyItems(): @{String: KittyHat} {
+        access(all) fun getKittyItems(): @{String: KittyHat} {
             var other: @{String:KittyHat} <- {}
             self.items <-> other
             return <- other
         }
 
-        pub fun setKittyItems(items: @{String: KittyHat}) {
+        access(all) fun setKittyItems(items: @{String: KittyHat}) {
             var other <- items
             self.items <-> other
             destroy other
         }
 
-        pub fun removeKittyItem(key: String): @KittyHat? {
+        access(all) fun removeKittyItem(key: String): @KittyHat? {
             var removed <- self.items.remove(key: key)
             return <- removed
         }
@@ -155,7 +155,7 @@ pub contract KittyVerse {
         }
     }
 
-    pub fun createKitty(): @Kitty {
+    access(all) fun createKitty(): @Kitty {
         return <-create Kitty(newID: 1)
     }
 
@@ -169,7 +169,7 @@ The hats are stored in a variable in the Kitty resource.
 
 ```cadence
     // place where the Kitty hats are stored
-    pub var items: <-{String: KittyHat}
+    access(all) var items: <-{String: KittyHat}
 ```
 
 A Kitty owner can take the hats off the Kitty and transfer them individually. Or the owner can transfer a Kitty that owns a hat, and the hat will go along with the Kitty.

--- a/docs/concepts/core-contracts/03-flow-token.md
+++ b/docs/concepts/core-contracts/03-flow-token.md
@@ -55,7 +55,7 @@ Event that is emitted when the contract gets created.
 - Testnet event: `A.7e60df042a9c0868.FlowToken.TokensInitialized`
 
 ```cadence
-pub event TokensInitialized(initialSupply: UFix64)
+access(all) event TokensInitialized(initialSupply: UFix64)
 ```
 
 | Field             | Type   | Description                                                            |
@@ -72,7 +72,7 @@ Event that is emitted when tokens get withdrawn from a Vault.
 - Testnet event: `A.7e60df042a9c0868.FlowToken.TokensWithdrawn`
 
 ```cadence
-pub event TokensWithdrawn(amount: UFix64, from: Address?)
+access(all) event TokensWithdrawn(amount: UFix64, from: Address?)
 ```
 
 | Field             | Type   | Description                                                            |
@@ -90,7 +90,7 @@ Event that is emitted when tokens get deposited to a Vault.
 - Testnet event: `A.7e60df042a9c0868.FlowToken.TokensDeposited`
 
 ```cadence
-pub event TokensDeposited(amount: UFix64, to: Address?)
+access(all) event TokensDeposited(amount: UFix64, to: Address?)
 ```
 
 | Field             | Type   | Description                                                            |
@@ -107,7 +107,7 @@ Event that is emitted when new tokens gets minted.
 - Testnet event: `A.7e60df042a9c0868.FlowToken.TokensMinted`
 
 ```cadence
-pub event TokensMinted(amount: UFix64)
+access(all) event TokensMinted(amount: UFix64)
 ```
 
 | Field             | Type   | Description                                                            |
@@ -123,7 +123,7 @@ Event that is emitted when tokens get destroyed.
 - Testnet event: `A.7e60df042a9c0868.FlowToken.TokensBurned`
 
 ```cadence
-pub event TokensBurned(amount: UFix64)
+access(all) event TokensBurned(amount: UFix64)
 ```
 
 | Field             | Type   | Description                                                            |
@@ -140,7 +140,7 @@ Event that is emitted when a new minter resource gets created.
 - Testnet event: `A.7e60df042a9c0868.FlowToken.MinterCreated`
 
 ```cadence
-pub event MinterCreated(allowedAmount: UFix64)
+access(all) event MinterCreated(allowedAmount: UFix64)
 ```
 
 | Field             | Type   | Description                                                            |
@@ -156,7 +156,7 @@ Event that is emitted when a new burner Resource gets created.
 - Testnet event: `A.7e60df042a9c0868.FlowToken.BurnerCreated`
 
 ```cadence
-pub event BurnerCreated()
+access(all) event BurnerCreated()
 ```
 
 ### Staking Events

--- a/docs/concepts/core-contracts/06-staking-contract-reference.md
+++ b/docs/concepts/core-contracts/06-staking-contract-reference.md
@@ -47,31 +47,31 @@ The `FlowIDTableStaking` contract emits an event whenever an important action oc
 See the [staking events Documentation](../staking/07-staking-scripts-events.md) for more information about each event.
 
 ```cadence
-    pub event NewEpoch(totalStaked: UFix64, totalRewardPayout: UFix64)
+    access(all) event NewEpoch(totalStaked: UFix64, totalRewardPayout: UFix64)
 
     /// Node Events
-    pub event NewNodeCreated(nodeID: String, role: UInt8, amountCommitted: UFix64)
-    pub event TokensCommitted(nodeID: String, amount: UFix64)
-    pub event TokensStaked(nodeID: String, amount: UFix64)
-    pub event TokensUnstaking(nodeID: String, amount: UFix64)
-    pub event TokensUnstaked(nodeID: String, amount: UFix64)
-    pub event NodeRemovedAndRefunded(nodeID: String, amount: UFix64)
-    pub event RewardsPaid(nodeID: String, amount: UFix64)
-    pub event UnstakedTokensWithdrawn(nodeID: String, amount: UFix64)
-    pub event RewardTokensWithdrawn(nodeID: String, amount: UFix64)
+    access(all) event NewNodeCreated(nodeID: String, role: UInt8, amountCommitted: UFix64)
+    access(all) event TokensCommitted(nodeID: String, amount: UFix64)
+    access(all) event TokensStaked(nodeID: String, amount: UFix64)
+    access(all) event TokensUnstaking(nodeID: String, amount: UFix64)
+    access(all) event TokensUnstaked(nodeID: String, amount: UFix64)
+    access(all) event NodeRemovedAndRefunded(nodeID: String, amount: UFix64)
+    access(all) event RewardsPaid(nodeID: String, amount: UFix64)
+    access(all) event UnstakedTokensWithdrawn(nodeID: String, amount: UFix64)
+    access(all) event RewardTokensWithdrawn(nodeID: String, amount: UFix64)
 
     /// Delegator Events
-    pub event NewDelegatorCreated(nodeID: String, delegatorID: UInt32)
-    pub event DelegatorTokensCommitted(nodeID: String, delegatorID: UInt32, amount: UFix64)
-    pub event DelegatorTokensStaked(nodeID: String, delegatorID: UInt32, amount: UFix64)
-    pub event DelegatorTokensUnstaking(nodeID: String, delegatorID: UInt32, amount: UFix64)
-    pub event DelegatorTokensUnstaked(nodeID: String, delegatorID: UInt32, amount: UFix64)
-    pub event DelegatorRewardsPaid(nodeID: String, delegatorID: UInt32, amount: UFix64)
-    pub event DelegatorUnstakedTokensWithdrawn(nodeID: String, delegatorID: UInt32, amount: UFix64)
-    pub event DelegatorRewardTokensWithdrawn(nodeID: String, delegatorID: UInt32, amount: UFix64)
+    access(all) event NewDelegatorCreated(nodeID: String, delegatorID: UInt32)
+    access(all) event DelegatorTokensCommitted(nodeID: String, delegatorID: UInt32, amount: UFix64)
+    access(all) event DelegatorTokensStaked(nodeID: String, delegatorID: UInt32, amount: UFix64)
+    access(all) event DelegatorTokensUnstaking(nodeID: String, delegatorID: UInt32, amount: UFix64)
+    access(all) event DelegatorTokensUnstaked(nodeID: String, delegatorID: UInt32, amount: UFix64)
+    access(all) event DelegatorRewardsPaid(nodeID: String, delegatorID: UInt32, amount: UFix64)
+    access(all) event DelegatorUnstakedTokensWithdrawn(nodeID: String, delegatorID: UInt32, amount: UFix64)
+    access(all) event DelegatorRewardTokensWithdrawn(nodeID: String, delegatorID: UInt32, amount: UFix64)
 
     /// Contract Field Change Events
-    pub event NewDelegatorCutPercentage(newCutPercentage: UFix64)
-    pub event NewWeeklyPayout(newPayout: UFix64)
-    pub event NewStakingMinimums(newMinimums: {UInt8: UFix64})
+    access(all) event NewDelegatorCutPercentage(newCutPercentage: UFix64)
+    access(all) event NewWeeklyPayout(newPayout: UFix64)
+    access(all) event NewStakingMinimums(newMinimums: {UInt8: UFix64})
 ```

--- a/docs/concepts/core-contracts/10-nft-storefront.md
+++ b/docs/concepts/core-contracts/10-nft-storefront.md
@@ -142,13 +142,13 @@ For NFT listings in marketplaces which don't require commission, commission rece
 
 ```cadence
 resource interface ListingPublic {
-    pub fun borrowNFT(): &NonFungibleToken.NFT?
-    pub fun purchase(
+    access(all) fun borrowNFT(): &NonFungibleToken.NFT?
+    access(all) fun purchase(
           payment: @FungibleToken.Vault, 
           commissionRecipient: Capability<&{FungibleToken.Receiver}>?,
       ): @NonFungibleToken.NFT
-    pub fun getDetails(): ListingDetail
-    pub fun getAllowedCommissionReceivers(): [Capability<&{FungibleToken.Receiver}>]?
+    access(all) fun getDetails(): ListingDetail
+    access(all) fun getAllowedCommissionReceivers(): [Capability<&{FungibleToken.Receiver}>]?
 }
 ```
 An interface providing a useful public interface to a Listing.
@@ -199,7 +199,7 @@ If it returns `nil` then commission is up to grab by anyone.
 
 ```cadence
 resource Storefront {
-    pub fun createListing(
+    access(all) fun createListing(
             nftProviderCapability: Capability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>,
             nftType: Type,
             nftID: UInt64,
@@ -210,11 +210,11 @@ resource Storefront {
             commissionAmount: UFix64,
             expiry: UInt64
          ): UInt64
-    pub fun removeListing(listingResourceID: UInt64)
-    pub fun getListingIDs(): [UInt64]
-    pub fun getDuplicateListingIDs(nftType: Type, nftID: UInt64, listingID: UInt64): [UInt64]
-    pub fun cleanupExpiredListings(fromIndex: UInt64, toIndex: UInt64)
-    pub fun borrowListing(listingResourceID: UInt64): &Listing{ListingPublic}?
+    access(all) fun removeListing(listingResourceID: UInt64)
+    access(all) fun getListingIDs(): [UInt64]
+    access(all) fun getDuplicateListingIDs(nftType: Type, nftID: UInt64, listingID: UInt64): [UInt64]
+    access(all) fun cleanupExpiredListings(fromIndex: UInt64, toIndex: UInt64)
+    access(all) fun borrowListing(listingResourceID: UInt64): &Listing{ListingPublic}?
 }
 ```
 A resource that allows its owner to manage a list of Listings, and anyone to interact with them
@@ -297,12 +297,12 @@ Returns a read-only view of the listing for the given listingID if it is contain
 
 ```cadence
 resource interface StorefrontPublic {
-    pub fun getListingIDs(): [UInt64]
-    pub fun getDuplicateListingIDs(nftType: Type, nftID: UInt64, listingID: UInt64): [UInt64]
-    pub fun cleanupExpiredListings(fromIndex: UInt64, toIndex: UInt64)
-    pub fun borrowListing(listingResourceID: UInt64): &Listing{ListingPublic}?
-    pub fun cleanupPurchasedListings(listingResourceID: UInt64)
-    pub fun getExistingListingIDs(nftType: Type, nftID: UInt64): [UInt64]
+    access(all) fun getListingIDs(): [UInt64]
+    access(all) fun getDuplicateListingIDs(nftType: Type, nftID: UInt64, listingID: UInt64): [UInt64]
+    access(all) fun cleanupExpiredListings(fromIndex: UInt64, toIndex: UInt64)
+    access(all) fun borrowListing(listingResourceID: UInt64): &Listing{ListingPublic}?
+    access(all) fun cleanupPurchasedListings(listingResourceID: UInt64)
+    access(all) fun getExistingListingIDs(nftType: Type, nftID: UInt64): [UInt64]
 }
 ```
 

--- a/docs/concepts/core-contracts/11-staking-collection.md
+++ b/docs/concepts/core-contracts/11-staking-collection.md
@@ -82,11 +82,11 @@ to be interacted with using the Staking Collection API.
 The `StakingCollection` contract emits an event whenever an important action occurs.
 
 ```cadence
-    pub event NodeAddedToStakingCollection(nodeID: String, role: UInt8, amountCommitted: UFix64, address: Address?)
-    pub event DelegatorAddedToStakingCollection(nodeID: String, delegatorID: UInt32, amountCommitted: UFix64, address: Address?)
+    access(all) event NodeAddedToStakingCollection(nodeID: String, role: UInt8, amountCommitted: UFix64, address: Address?)
+    access(all) event DelegatorAddedToStakingCollection(nodeID: String, delegatorID: UInt32, amountCommitted: UFix64, address: Address?)
 
-    pub event NodeRemovedFromStakingCollection(nodeID: String, role: UInt8, address: Address?)
-    pub event DelegatorRemovedFromStakingCollection(nodeID: String, delegatorID: UInt32, address: Address?)
+    access(all) event NodeRemovedFromStakingCollection(nodeID: String, role: UInt8, address: Address?)
+    access(all) event DelegatorRemovedFromStakingCollection(nodeID: String, delegatorID: UInt32, address: Address?)
 
-    pub event MachineAccountCreated(nodeID: String, role: UInt8, address: Address)
+    access(all) event MachineAccountCreated(nodeID: String, role: UInt8, address: Address)
 ```

--- a/docs/concepts/flow-token/wallets.md
+++ b/docs/concepts/flow-token/wallets.md
@@ -60,7 +60,7 @@ The `FlowToken` contract emits a `FlowToken.TokensDeposited` event whenever toke
 move between accounts.
 
 ```cadence
-pub event TokensDeposited(amount: UFix64, to: Address?)
+access(all) event TokensDeposited(amount: UFix64, to: Address?)
 ```
 
 You can query for this event to detect when tokens are deposited into a user's account.

--- a/docs/concepts/hybrid-custody/guides/account-model.mdx
+++ b/docs/concepts/hybrid-custody/guides/account-model.mdx
@@ -171,7 +171,7 @@ This script will return `true` if a `HybridCustody.Manager` is stored and `false
 ```cadence get_child_addresses.cdc
 import "HybridCustody"
 
-pub fun main(parent: Address): Bool {
+access(all) fun main(parent: Address): Bool {
     let acct = getAuthAccount(parent)
     if let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
         return manager.getAddresses().length > 0
@@ -188,7 +188,7 @@ address.
 ```cadence get_child_addresses.cdc
 import "HybridCustody"
 
-pub fun main(parent: Address): [Address] {
+access(all) fun main(parent: Address): [Address] {
     let acct = getAuthAccount(parent)
     let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
         ?? panic("manager not found")
@@ -213,7 +213,7 @@ import "HybridCustody"
 
 /// Returns resolved Display from given address at specified path for each ID or nil if ResolverCollection is not found
 ///
-pub fun getViews(_ address: Address, _ resolverCollectionPath: PublicPath): {UInt64: MetadataViews.Display} {
+access(all) fun getViews(_ address: Address, _ resolverCollectionPath: PublicPath): {UInt64: MetadataViews.Display} {
 
     let account: PublicAccount = getAccount(address)
     let views: {UInt64: MetadataViews.Display} = {}
@@ -234,7 +234,7 @@ pub fun getViews(_ address: Address, _ resolverCollectionPath: PublicPath): {UIn
 /// Queries MetadataViews.Display for each NFT across all associated accounts from Collections at the provided
 /// PublicPath
 ///
-pub fun main(address: Address, resolverCollectionPath: PublicPath): {Address: {UInt64: MetadataViews.Display}} {
+access(all) fun main(address: Address, resolverCollectionPath: PublicPath): {Address: {UInt64: MetadataViews.Display}} {
 
     let allViews: {Address: {UInt64: MetadataViews.Display}} = {address: getViews(address, resolverCollectionPath)}
     let seen: [Address] = [address]
@@ -280,7 +280,7 @@ import "HybridCustody"
 
 /// Returns a mapping of balances indexed on the Type of resource containing the balance
 ///
-pub fun getAllBalancesInStorage(_ address: Address): {Type: UFix64} {
+access(all) fun getAllBalancesInStorage(_ address: Address): {Type: UFix64} {
     // Get the account
     let account: AuthAccount = getAuthAccount(address)
     // Init for return value
@@ -310,7 +310,7 @@ pub fun getAllBalancesInStorage(_ address: Address): {Type: UFix64} {
 
 /// Queries for FT.Vault balance of all FT.Vaults in the specified account and all of its associated accounts
 ///
-pub fun main(address: Address): {Address: {Type: UFix64}} {
+access(all) fun main(address: Address): {Address: {Type: UFix64}} {
 
     // Get the balance for the given address
     let balances: {Address: {Type: UFix64}} = { address: getAllBalancesInStorage(address) }

--- a/docs/concepts/mobile/monster-maker.md
+++ b/docs/concepts/mobile/monster-maker.md
@@ -150,14 +150,14 @@ To view the NFT from an wallet address, first and foremost, we highly recommend 
         import MonsterMaker from 0xMonsterMaker
         import MetadataViews from 0xMetadataViews
         
-        pub struct Monster {
-            pub let name: String
-            pub let description: String
-            pub let thumbnail: String
-            pub let itemID: UInt64
-            pub let resourceID: UInt64
-            pub let owner: Address
-            pub let component: MonsterMaker.MonsterComponent
+        access(all) struct Monster {
+            access(all) let name: String
+            access(all) let description: String
+            access(all) let thumbnail: String
+            access(all) let itemID: UInt64
+            access(all) let resourceID: UInt64
+            access(all) let owner: Address
+            access(all) let component: MonsterMaker.MonsterComponent
     
             init(
                 name: String,
@@ -178,7 +178,7 @@ To view the NFT from an wallet address, first and foremost, we highly recommend 
             }
         }
     
-        pub fun getMonsterById(address: Address, itemID: UInt64): Monster? {
+        access(all) fun getMonsterById(address: Address, itemID: UInt64): Monster? {
     
             if let collection = getAccount(address).getCapability<&MonsterMaker.Collection{NonFungibleToken.CollectionPublic, MonsterMaker.MonsterMakerCollectionPublic}>(MonsterMaker.CollectionPublicPath).borrow() {
                 
@@ -204,7 +204,7 @@ To view the NFT from an wallet address, first and foremost, we highly recommend 
             return nil
         }
     
-        pub fun main(address: Address): [Monster] {
+        access(all) fun main(address: Address): [Monster] {
             let account = getAccount(address)
             let collectionRef = account.getCapability(MonsterMaker.CollectionPublicPath)!.borrow<&{NonFungibleToken.CollectionPublic}>()
                 ?? panic("Could not borrow capability from public collection")

--- a/docs/concepts/mobile/react-native-quickstart.mdx
+++ b/docs/concepts/mobile/react-native-quickstart.mdx
@@ -229,7 +229,7 @@ export default function App() {
       cadence: `
         import Profile from 0xProfile
 
-        pub fun main(address: Address): Profile.ReadOnly? {
+        access(all) fun main(address: Address): Profile.ReadOnly? {
           return Profile.read(address)
         }
       `,
@@ -283,7 +283,7 @@ await fcl.query({
   cadence: `
     import Profile from 0xProfile
 
-    pub fun main(address: Address): Profile.ReadOnly? {
+    access(all) fun main(address: Address): Profile.ReadOnly? {
       return Profile.read(address)
     }
   `,
@@ -367,7 +367,7 @@ export default function App() {
       cadence: `
         import Profile from 0xProfile
 
-        pub fun main(address: Address): Profile.ReadOnly? {
+        access(all) fun main(address: Address): Profile.ReadOnly? {
           return Profile.read(address)
         }
       `,
@@ -504,7 +504,7 @@ export default function App() {
       cadence: `
         import Profile from 0xProfile
 
-        pub fun main(address: Address): Profile.ReadOnly? {
+        access(all) fun main(address: Address): Profile.ReadOnly? {
           return Profile.read(address)
         }
       `,

--- a/docs/concepts/nodes/node-operation/FAQ.md
+++ b/docs/concepts/nodes/node-operation/FAQ.md
@@ -54,7 +54,7 @@ More on this [here](./node-migration.mdx)
 
 ### Where can I find how many nodes are currently running Flow?
 
-If you are running a node, then you most definitely have this information on your node in the file `<your bootstrap dir>/public-root-information/node-infos.pub.json`. If you are not running a node, you can find this information by using a Cadence script to query the [Staking Smart Contract](../../core-contracts/06-staking-contract-reference.md) (or check [Flowscan](https://flowscan.org/staking/overview))
+If you are running a node, then you most definitely have this information on your node in the file `<your bootstrap dir>/public-root-information/node-infos.access(all).json`. If you are not running a node, you can find this information by using a Cadence script to query the [Staking Smart Contract](../../core-contracts/06-staking-contract-reference.md) (or check [Flowscan](https://flowscan.org/staking/overview))
 
 ### Why do I need to update my node's ulimit?
 

--- a/docs/concepts/nodes/node-operation/access-node-setup.md
+++ b/docs/concepts/nodes/node-operation/access-node-setup.md
@@ -105,7 +105,7 @@ $./boot-tools/bootstrap key --address "flowaccess.mycompany.com:3569" --role acc
 <nil> INF wrote file bootstrap/public-root-information/node-id
 <nil> INF wrote file bootstrap/private-root-information/private-node-info_e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5/node-info.priv.json
 <nil> INF wrote file bootstrap/private-root-information/private-node-info_e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5/secretsdb-key
-<nil> INF wrote file bootstrap/public-root-information/node-info.pub.e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5.json
+<nil> INF wrote file bootstrap/public-root-information/node-info.access(all).e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5.json
 
 $tree ./bootstrap/
 ./bootstrap/
@@ -115,7 +115,7 @@ $tree ./bootstrap/
 │        └── secretsdb-key
 └── public-root-information
     ├── node-id
-    └── node-info.pub.e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5.json
+    └── node-info.access(all).e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5.json
 
 3 directories, 4 files
 ```
@@ -150,10 +150,10 @@ On Flow port, choose `Stake and Delegate` -> `Start Staking` or `Stake Again` an
 
 On the next screen, provide the node details of you node.
 
-Those node details (`Node ID`, `Network Address`, `Networking Key` and `Staking Key`) can be found in the file: `./bootstrap/public-root-information/node-info.pub.<node-id>.json`.
+Those node details (`Node ID`, `Network Address`, `Networking Key` and `Staking Key`) can be found in the file: `./bootstrap/public-root-information/node-info.access(all).<node-id>.json`.
 
 ```shell Example
-$cat ./bootstrap/public-root-information/node-info.pub. e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5.json
+$cat ./bootstrap/public-root-information/node-info.access(all). e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5.json
 {
   "Role": "access",
   "Address": "flowaccess.mycompany.com:3569",

--- a/docs/concepts/nodes/node-operation/db-encryption-existing-operator.mdx
+++ b/docs/concepts/nodes/node-operation/db-encryption-existing-operator.mdx
@@ -49,7 +49,7 @@ $tree ./bootstrap/
 │       └── secretsdb-key
 └── public-root-information
     ├── node-id
-    └── node-info.pub.ab6e0b15837de7e5261777cb65665b318cf3f94492dde27c1ea13830e989bbf9.json
+    └── node-info.access(all).ab6e0b15837de7e5261777cb65665b318cf3f94492dde27c1ea13830e989bbf9.json
 
 3 directories, 4 files
 ```

--- a/docs/concepts/nodes/node-operation/guides/genesis-bootstrap.mdx
+++ b/docs/concepts/nodes/node-operation/guides/genesis-bootstrap.mdx
@@ -65,7 +65,7 @@ The bootstrapping process will create a file structure similar to the following
 ~
 └──bootstrap
    ├──{id}.node-info.priv.json
-   └──{id}.node-info.pub.json",
+   └──{id}.node-info.access(all).json",
 ```
 
 ## Upload Public Keys
@@ -74,7 +74,7 @@ To mint the Genesis Block, the Flow team will need the public Staking and Networ
 
 **If you have previously joined our networks, and you are generating your keys again. Ensure that you take a backup of your keys before generating it again**
 
-To facilitate this, the boot-tools directory comes with a script `push-keys` that will bundle your `*.pub.json` files and send it to the flow team. You can inspect this script to make sure no private key material is being bundled or uploaded. The data not encrypted before being sent as the public keys involved are not sensitive.
+To facilitate this, the boot-tools directory comes with a script `push-keys` that will bundle your `*.access(all).json` files and send it to the flow team. You can inspect this script to make sure no private key material is being bundled or uploaded. The data not encrypted before being sent as the public keys involved are not sensitive.
 
 In phase 2 of the bootstrapping process, the Flow team will need to securely issue each node a Random Beacon key. This key is again sensitive and unique to your node. To enable this, the `push-keys` script also generates another key pair called the Transit Key. The public key of this pair will be uploaded along with the Staking and Network keys, and your Random Beacon key will be encrypted with it before being sent to you. You must keep your Transit Key until you have received and decrypted your Random Beacon key from the Flow team.
 
@@ -137,7 +137,7 @@ bootstrap/
 │ ├── node-info.priv.json
 │ └── random-beacon.priv.json
 ├── public-genesis-information
-│ ├── dkg-data.pub.json
+│ ├── dkg-data.access(all).json
 │ ├── genesis-block.json
 │ ├── genesis-cluster-block.{cid}.json
 │ ├── genesis-cluster-block.{cid}.json
@@ -146,8 +146,8 @@ bootstrap/
 │ ├── genesis-commit.json
 │ ├── genesis-qc.json
 │ ├── node-id
-│ ├── node-info.pub.{node id}.json
-│ └── node-infos.pub.json
+│ ├── node-info.access(all).{node id}.json
+│ └── node-infos.access(all).json
 ├── <additional files...>
 ```
 

--- a/docs/concepts/nodes/node-operation/machine-existing-operator.mdx
+++ b/docs/concepts/nodes/node-operation/machine-existing-operator.mdx
@@ -61,7 +61,7 @@ $tree ./bootstrap/
 │       └── secretsdb-key
 └── public-root-information
     ├── node-id
-    └── node-info.pub.ab6e0b15837de7e5261777cb65665b318cf3f94492dde27c1ea13830e989bbf9.json
+    └── node-info.access(all).ab6e0b15837de7e5261777cb65665b318cf3f94492dde27c1ea13830e989bbf9.json
 
 3 directories, 4 files
 ```
@@ -102,7 +102,7 @@ $tree ./bootstrap/
 │       └── secretsdb-key
 └── public-root-information
     ├── node-id
-    └── node-info.pub.d60bd55ee616c5c297cae1d5cfb7f65e7e04014d9c4abe595af2fd83f3cfe160.json
+    └── node-info.access(all).d60bd55ee616c5c297cae1d5cfb7f65e7e04014d9c4abe595af2fd83f3cfe160.json
 
 3 directories, 5 files
 ```

--- a/docs/concepts/nodes/node-operation/node-bootstrap.mdx
+++ b/docs/concepts/nodes/node-operation/node-bootstrap.mdx
@@ -104,7 +104,7 @@ $./boot-tools/bootstrap key --address "consensus-001.nodes.flow.com:3569" --role
 <nil> INF wrote file bootstrap/public-root-information/node-id
 <nil> INF wrote file bootstrap/private-root-information/private-node-info_ab6e0b15837de7e5261777cb65665b318cf3f94492dde27c1ea13830e989bbf9/node-info.priv.json
 <nil> INF wrote file bootstrap/private-root-information/private-node-info_5e44ad5598bb0acb44784f629e84000ffea34d5552427247d9008ccf147fb87f/secretsdb-key
-<nil> INF wrote file bootstrap/public-root-information/node-info.pub.ab6e0b15837de7e5261777cb65665b318cf3f94492dde27c1ea13830e989bbf9.json
+<nil> INF wrote file bootstrap/public-root-information/node-info.access(all).ab6e0b15837de7e5261777cb65665b318cf3f94492dde27c1ea13830e989bbf9.json
 <nil> DBG will generate machine account key
 <nil> INF generated machine account key
 <nil> DBG assembling machine account information address=consensus-001.nodes.flow.com:3569
@@ -120,7 +120,7 @@ $tree ./bootstrap/
 │       └── secretsdb-key
 └── public-root-information
     ├── node-id
-    └── node-info.pub.ab6e0b15837de7e5261777cb65665b318cf3f94492dde27c1ea13830e989bbf9.json
+    └── node-info.access(all).ab6e0b15837de7e5261777cb65665b318cf3f94492dde27c1ea13830e989bbf9.json
 
 3 directories, 4 files
 ```
@@ -158,10 +158,10 @@ Copy the machine account public key somewhere safe. You will need it in a later 
 
 Stake your node via [Flow Port](https://port.onflow.org/)
 
-The `node details` (`Node ID`, `Network Address`, `Networking Key` and `Staking Key`) that need to be submitted when staking the node on Flow Port, can be found in the file: `./bootstrap/public-root-information/node-info.pub.<node-id>.json`.
+The `node details` (`Node ID`, `Network Address`, `Networking Key` and `Staking Key`) that need to be submitted when staking the node on Flow Port, can be found in the file: `./bootstrap/public-root-information/node-info.access(all).<node-id>.json`.
 
 ```shell Example
-$cat ./bootstrap/public-root-information/node-info.pub.39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a.json
+$cat ./bootstrap/public-root-information/node-info.access(all).39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a.json
 {
   "Role": "consensus",
   "Address": "consensus-001.nodes.flow.com:3569",
@@ -211,7 +211,7 @@ $tree ./bootstrap/
 │       └── secretsdb-key
 └── public-root-information
     ├── node-id
-    └── node-info.pub.d60bd55ee616c5c297cae1d5cfb7f65e7e04014d9c4abe595af2fd83f3cfe160.json
+    └── node-info.access(all).d60bd55ee616c5c297cae1d5cfb7f65e7e04014d9c4abe595af2fd83f3cfe160.json
 
 3 directories, 5 files
 ```

--- a/docs/concepts/nodes/node-operation/spork.mdx
+++ b/docs/concepts/nodes/node-operation/spork.mdx
@@ -53,7 +53,7 @@ The Flow team will provide you a new token `PULL_TOKEN` to pull the genesis info
 $ ./boot-tools/transit pull -b ./bootstrap -t mainnet-16  -r consensus
 Transit script Commit: a9f6522855e119ad832a97f8b7bce555a163e490
 2020/11/25 01:02:53 Running pull
-2020/11/25 01:02:53 Downloading bootstrap/public-root-information/node-infos.pub.json
+2020/11/25 01:02:53 Downloading bootstrap/public-root-information/node-infos.access(all).json
 2020/11/25 01:02:54 Downloading bootstrap/public-root-information/root-protocol-snapshot.json
 2020/11/25 01:02:54 Downloading bootstrap/random-beacon.priv.json.39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a.enc
 2020/11/25 01:02:54 SHA256 of the root block is: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -65,8 +65,8 @@ $ tree ./bootstrap/
   │       └── node-info.priv.json
   ├── public-root-information
   │   ├── node-id
-  │   ├── node-info.pub.39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a.json
-  │   ├── node-infos.pub.json
+  │   ├── node-info.access(all).39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a.json
+  │   ├── node-infos.access(all).json
   │   └── root-protocol-snapshot.json
   └── random-beacon.priv.json.39fa54984b8eaa463e129919464f61c8cec3a4389478df79c44eb9bfbf30799a
 ```

--- a/docs/concepts/staking/05-epoch-scripts-events.md
+++ b/docs/concepts/staking/05-epoch-scripts-events.md
@@ -60,7 +60,7 @@ It contains the finalized identity table for the upcoming epoch,
 as well as timing information for phase changes.
 
 ```cadence
-pub event EpochSetup (
+access(all) event EpochSetup (
 
     /// The counter for the upcoming epoch. Must be one greater than the
     /// counter for the current epoch.
@@ -104,7 +104,7 @@ from the Epoch Setup phase to the Epoch Commit phase.
 It is emitted only when all preparation for the upcoming epoch (QC and DKG) has been completed.
 
 ```cadence
-pub event EpochCommit (
+access(all) event EpochCommit (
 
     /// The counter for the upcoming epoch. Must be equal to the counter in the
     /// previous EpochSetup event.
@@ -130,43 +130,43 @@ and previous epochs. Metadata for all historical epochs is stored permenantely
 in the Epoch Smart Contract's storage.
 
 ```cadence
-pub struct EpochMetadata {
+access(all) struct EpochMetadata {
 
     /// The identifier for the epoch
-    pub let counter: UInt64
+    access(all) let counter: UInt64
 
     /// The seed used for generating the epoch setup
-    pub let seed: String
+    access(all) let seed: String
 
     /// The first view of this epoch
-    pub let startView: UInt64
+    access(all) let startView: UInt64
 
     /// The last view of this epoch
-    pub let endView: UInt64
+    access(all) let endView: UInt64
 
     /// The last view of the staking auction
-    pub let stakingEndView: UInt64
+    access(all) let stakingEndView: UInt64
 
     /// The total rewards that are paid out for the epoch
-    pub var totalRewards: UFix64
+    access(all) var totalRewards: UFix64
 
     /// The reward amounts that are paid to each individual node and its delegators
-    pub var rewardAmounts: [FlowIDTableStaking.RewardsBreakdown]
+    access(all) var rewardAmounts: [FlowIDTableStaking.RewardsBreakdown]
 
     /// Tracks if rewards have been paid for this epoch
-    pub var rewardsPaid: Bool
+    access(all) var rewardsPaid: Bool
 
     /// The organization of collector node IDs into clusters
     /// determined by a round robin sorting algorithm
-    pub let collectorClusters: [FlowClusterQC.Cluster]
+    access(all) let collectorClusters: [FlowClusterQC.Cluster]
 
     /// The Quorum Certificates from the ClusterQC contract
-    pub var clusterQCs: [FlowClusterQC.ClusterQC]
+    access(all) var clusterQCs: [FlowClusterQC.ClusterQC]
 
     /// The public keys associated with the Distributed Key Generation
     /// process that consensus nodes participate in
     /// Group key is the last element at index: length - 1
-    pub var dkgKeys: [String]
+    access(all) var dkgKeys: [String]
 }
 ```
 
@@ -188,7 +188,7 @@ The `FlowEpoch` smart contract also has a set of metadata that is configurable b
 for phase lengths, number of collector clusters, and inflation percentage.
 
 ```cadence
-pub struct Config {
+access(all) struct Config {
     /// The number of views in an entire epoch
     pub(set) var numViewsInEpoch: UInt64
 
@@ -226,10 +226,10 @@ This script does not require any arguments.
 The `FlowEpoch` smart contract always tracks the active phase of the current epoch.
 
 ```cadence
-pub enum EpochPhase: UInt8 {
-    pub case STAKINGAUCTION
-    pub case EPOCHSETUP
-    pub case EPOCHCOMMIT
+access(all) enum EpochPhase: UInt8 {
+    access(all) case STAKINGAUCTION
+    access(all) case EPOCHSETUP
+    access(all) case EPOCHCOMMIT
 }
 ```
 

--- a/docs/concepts/staking/07-staking-scripts-events.md
+++ b/docs/concepts/staking/07-staking-scripts-events.md
@@ -146,7 +146,7 @@ state of the staking process.
 ### NewEpoch
 
 ```cadence
-pub event NewEpoch(totalStaked: UFix64, totalRewardPayout: UFix64)
+access(all) event NewEpoch(totalStaked: UFix64, totalRewardPayout: UFix64)
 ```
 
 | Field             | Type   | Description                                                            |
@@ -159,7 +159,7 @@ Emitted by `FlowIDTableStaking.Admin.moveTokens()` when the tokens are moved bet
 ### NewWeeklyPayout
 
 ```cadence
-pub event NewWeeklyPayout(newPayout: UFix64)
+access(all) event NewWeeklyPayout(newPayout: UFix64)
 ```
 
 | Field     | Type   | Description                                                        |
@@ -173,7 +173,7 @@ After this event the `epochTokenPayout` is equal to the new value.
 ### NewStakingMinimums
 
 
-`pub event NewStakingMinimums(newMinimums: {UInt8: UFix64})`
+`access(all) event NewStakingMinimums(newMinimums: {UInt8: UFix64})`
 
 
 | Field           | Type            | Description                                                  |
@@ -185,7 +185,7 @@ Emitted by `FlowIDTableStaking.Admin.setMinimumStakeRequirements()` when the Adm
 ### NewDelegatorCutPercentage
 
 
-`pub event NewDelegatorCutPercentage(newCutPercentage: UFix64)`
+`access(all) event NewDelegatorCutPercentage(newCutPercentage: UFix64)`
 
 
 | Field            | Type   | Description                                                         |
@@ -207,7 +207,7 @@ These are events that concern the operation of a node.
 ### NewNodeCreated
 
 ```cadence
-pub event NewNodeCreated(nodeID: String, role: UInt8, amountCommitted: UFix64)
+access(all) event NewNodeCreated(nodeID: String, role: UInt8, amountCommitted: UFix64)
 ```
 
 | Field           | Type   | Description                                                                                                                                                                                         |
@@ -223,7 +223,7 @@ After this event is emitted for your node, you can begin to perform staking tran
 ### NodeRemovedAndRefunded
 
 ```cadence
-pub event NodeRemovedAndRefunded(nodeID: String, amount: UFix64)
+access(all) event NodeRemovedAndRefunded(nodeID: String, amount: UFix64)
 ```
 
 | Field  | Type   | Description                                                                                                     |
@@ -245,7 +245,7 @@ Events emitted when using delegation are described in the next section.
 ### TokensCommitted
 
 ```cadence
-pub event TokensCommitted(nodeID: String, amount: UFix64)
+access(all) event TokensCommitted(nodeID: String, amount: UFix64)
 ```
 
 | Field  | Type   | Description                                                                                                     |
@@ -267,7 +267,7 @@ After this event, the FLOW tokens will be part of the node's `tokensCommitted` b
 ### TokensStaked
 
 ```cadence
-pub event TokensStaked(nodeID: String, amount: UFix64)
+access(all) event TokensStaked(nodeID: String, amount: UFix64)
 ```
 
 | Field  | Type   | Description                                                                                                     |
@@ -282,7 +282,7 @@ After this event, the tokens will be part of the node's staked balance.
 ### TokensUnstaking
 
 ```cadence
-pub event TokensUnstaking(nodeID: String, amount: UFix64)
+access(all) event TokensUnstaking(nodeID: String, amount: UFix64)
 ```
 
 | Field  | Type   | Description                                                                                                     |
@@ -297,7 +297,7 @@ After this event, the tokens will be a part of the node operator's `tokensUnstak
 ### TokensUnstaked
 
 ```cadence
-pub event TokensUnstaked(nodeID: String, amount: UFix64)
+access(all) event TokensUnstaked(nodeID: String, amount: UFix64)
 ```
 
 | Field  | Type   | Description                                                                                                     |
@@ -311,7 +311,7 @@ when tokens are deposited into the `tokensUnstaked` pool:
 ### RewardsPaid
 
 ```cadence
-pub event RewardsPaid(nodeID: String, amount: UFix64)
+access(all) event RewardsPaid(nodeID: String, amount: UFix64)
 ```
 
 | Field  | Type   | Description                                                                                                     |
@@ -328,7 +328,7 @@ The Delegator rewards are paid at the same time, see `DelegatorRewardsPaid` belo
 ### UnstakedTokensWithdrawn
 
 ```cadence
-pub event UnstakedTokensWithdrawn(nodeID: String, amount: UFix64)
+access(all) event UnstakedTokensWithdrawn(nodeID: String, amount: UFix64)
 ```
 
 | Field  | Type   | Description                                                                                                     |
@@ -344,7 +344,7 @@ After this event, the FLOW tokens will be withdrawn to a newly created `Fungible
 ### RewardTokensWithdrawn
 
 ```cadence
-pub event RewardTokensWithdrawn(nodeID: String, amount: UFix64)
+access(all) event RewardTokensWithdrawn(nodeID: String, amount: UFix64)
 ```
 
 | Field  | Type   | Description                                                                                                     |
@@ -364,7 +364,7 @@ These are events that concern FLOW token delegation.
 ### NewDelegatorCreated
 
 ```cadence
-pub event NewDelegatorCreated(nodeID: String, delegatorID: UInt32)
+access(all) event NewDelegatorCreated(nodeID: String, delegatorID: UInt32)
 ```
 
 | Field       | Type   | Description                                                                                                     |
@@ -381,7 +381,7 @@ After this event, the new delegator is registered with the node.
 ### DelegatorTokensCommitted
 
 ```cadence
-pub event DelegatorTokensCommitted(nodeID: String, delegatorID: UInt32, amount: UFix64)
+access(all) event DelegatorTokensCommitted(nodeID: String, delegatorID: UInt32, amount: UFix64)
 ```
 
 | Field       | Type   | Description                                                                                                     |
@@ -404,7 +404,7 @@ After this event, the FLOW tokens will be part of the delegator's `tokensCommitt
 ### DelegatorTokensStaked
 
 ```cadence
-pub event DelegatorTokensStaked(nodeID: String, delegatorID: UInt32, amount: UFix64)
+access(all) event DelegatorTokensStaked(nodeID: String, delegatorID: UInt32, amount: UFix64)
 ```
 
 | Field       | Type   | Description                                                                                                     |
@@ -420,7 +420,7 @@ After this event, the tokens will be part of the delegator's staked balance.
 ### DelegatorTokensUnstaking
 
 ```cadence
-pub event DelegatorTokensUnstaking(nodeID: String, delegatorID: UInt32, amount: UFix64)
+access(all) event DelegatorTokensUnstaking(nodeID: String, delegatorID: UInt32, amount: UFix64)
 ```
 
 | Field       | Type   | Description                                                                                                     |
@@ -436,7 +436,7 @@ After this event, the tokens will be a part of the delegator's `tokensUnstaking`
 ### DelegatorTokensUnstaked
 
 ```cadence
-pub event DelegatorTokensUnstaked(nodeID: String, delegatorID: UInt32, amount: UFix64)
+access(all) event DelegatorTokensUnstaked(nodeID: String, delegatorID: UInt32, amount: UFix64)
 ```
 
 | Field       | Type   | Description                                                                                                     |
@@ -451,7 +451,7 @@ when tokens are deposited into the delegator's `tokensUnstaked` pool:
 ### DelegatorRewardsPaid
 
 ```cadence
-pub event DelegatorRewardsPaid(nodeID: String, delegatorID: UInt32, amount: UFix64)
+access(all) event DelegatorRewardsPaid(nodeID: String, delegatorID: UInt32, amount: UFix64)
 ```
 
 | Field       | Type   | Description                                                                                                     |
@@ -469,7 +469,7 @@ The Node rewards are paid at the same time, see `RewardsPaid` above.
 ### DelegatorUnstakedTokensWithdrawn
 
 ```cadence
-pub event DelegatorUnstakedTokensWithdrawn(nodeID: String, delegatorID: UInt32, amount: UFix64)
+access(all) event DelegatorUnstakedTokensWithdrawn(nodeID: String, delegatorID: UInt32, amount: UFix64)
 ```
 
 | Field       | Type   | Description                                                                                                     |
@@ -486,7 +486,7 @@ After this event, the FLOW tokens will be withdrawn to a newly created `Fungible
 ### DelegatorRewardTokensWithdrawn
 
 ```cadence
-pub event DelegatorRewardTokensWithdrawn(nodeID: String, delegatorID: UInt32, amount: UFix64)
+access(all) event DelegatorRewardTokensWithdrawn(nodeID: String, delegatorID: UInt32, amount: UFix64)
 ```
 
 | Field       | Type   | Description                                                                                                     |

--- a/docs/concepts/staking/10-qc-dkg-scripts-events.md
+++ b/docs/concepts/staking/10-qc-dkg-scripts-events.md
@@ -88,11 +88,11 @@ can use the **Get Node Has Submitted** ([DKG.08](../core-contracts/07-epoch-cont
 
 ```cadence
 /// Emitted when the admin enables the DKG
-pub event StartDKG()
+access(all) event StartDKG()
 
 /// Emitted when the admin ends the DKG after enough submissions have been recorded
-pub event EndDKG(finalSubmission: [String?]?)
+access(all) event EndDKG(finalSubmission: [String?]?)
 
 /// Emitted when a consensus node has posted a message to the DKG whiteboard
-pub event BroadcastMessage(nodeID: String, content: String)
+access(all) event BroadcastMessage(nodeID: String, content: String)
 ```

--- a/docs/concepts/staking/14-staking-collection.mdx
+++ b/docs/concepts/staking/14-staking-collection.mdx
@@ -104,7 +104,7 @@ import FlowStakingCollection from 0xSTAKINGCOLLECTIONADDRESS
 import FlowIDTableStaking from 0xIDENTITYTABLEADDRESS
 
 /// Gets an array of all the delegator metadata for delegators stored in the staking collection
-pub fun main(address: Address): [FlowIDTableStaking.DelegatorInfo] {
+access(all) fun main(address: Address): [FlowIDTableStaking.DelegatorInfo] {
     return FlowStakingCollection.getAllDelegatorInfo(address: address)
 }
 ```

--- a/docs/concepts/start-here/storage.md
+++ b/docs/concepts/start-here/storage.md
@@ -62,7 +62,7 @@ Storage fees were put in place to regulate the growth of data stored on the Flow
 The values of storage used and storage capacity are available as fields both on `AuthAccount` and `PublicAccount` Cadence types.
 
 ```cadence
-pub fun main(address: Address) {
+access(all) fun main(address: Address) {
     let account = getAccount(address)
     log(account.storageUsed)
     log(account.storageCapacity)

--- a/docs/concepts/start-here/variable-transaction-fees.md
+++ b/docs/concepts/start-here/variable-transaction-fees.md
@@ -121,7 +121,7 @@ The cost for transactions can be calculated using the following FCL scripts on m
 
 ```cadence
 import FlowFees from 0xf919ee77447b7497
-pub fun main(
+access(all) fun main(
   inclusionEffort: UFix64,
   executionEffort: UFix64
 ): UFix64 {
@@ -133,7 +133,7 @@ pub fun main(
 
 ```cadence
 import FlowFees from 0x912d5440f7e3769e
-pub fun main(
+access(all) fun main(
   inclusionEffort: UFix64,
   executionEffort: UFix64
 ): UFix64 {
@@ -225,7 +225,7 @@ Whenever you want to iterate over a list, make sure it is necessary to iterate t
 
 ```cadence
 // Iterating over long lists can be costly
-pub fun sum(list: [Int]): Int {
+access(all) fun sum(list: [Int]): Int {
  var total = 0
  var i = 0
  // if list grows too large, this might not be possible anymore
@@ -236,7 +236,7 @@ pub fun sum(list: [Int]): Int {
 }
 
 // Consider designing transactions (and scripts) in a way where work can be "chunked" into smaller pieces
-pub fun partialSum(list: [Int], start: Int, end: Int): Int {
+access(all) fun partialSum(list: [Int], start: Int, end: Int): Int {
  var partialTotal = 0
  var i = start
  while i < end {
@@ -253,7 +253,7 @@ Some functions will require more execution efforts than others. You should caref
 ```cadence
 // be aware functions that call a lot of other functions
 // (or call themselves) might cost a lot
-pub fun fib(_ x: Int): Int {
+access(all) fun fib(_ x: Int): Int {
  if x == 1 || x== 0 {
    return x
  }
@@ -262,7 +262,7 @@ pub fun fib(_ x: Int): Int {
 }
 
 // consider inlining functions with single statements, to reduce costs
-pub fun add(_ a: Int, _ b: Int): Int {
+access(all) fun add(_ a: Int, _ b: Int): Int {
  // single statement; worth inlining
  return a + b
 }

--- a/docs/concepts/token-standards/flow-ft/index.md
+++ b/docs/concepts/token-standards/flow-ft/index.md
@@ -62,21 +62,21 @@ Right now we are using unsigned 64-bit fixed point numbers `UFix64` as the type 
 
 1- Getting metadata for the token smart contract via the fields of the contract:
 
-- `pub var totalSupply: UFix64`
+- `access(all) var totalSupply: UFix64`
     - The only required field of the contract.  It would be incremented when new tokens are minted and decremented when they are destroyed.
 - Event that gets emitted when the contract is initialized
-    - `pub event TokensInitialized(initialSupply: UFix64)`
+    - `access(all) event TokensInitialized(initialSupply: UFix64)`
 
 2- Retrieving the token fields of a `Vault` in an account that owns tokens.
 
 - Balance interface
-    - `pub var balance: UFix64`
+    - `access(all) var balance: UFix64`
         - The only required field of the `Vault` type
 
 3- Withdrawing a specific amount of tokens *amount* using the *withdraw* function of the owner's `Vault`
 
 - Provider interface
-    - `pub fun withdraw(amount: UFix64): @FungibleToken.Vault`
+    - `access(all) fun withdraw(amount: UFix64): @FungibleToken.Vault`
         - Conditions
             - the returned Vault's balance must equal the amount withdrawn
             - The amount withdrawn must be less than or equal to the balance
@@ -86,12 +86,12 @@ Right now we are using unsigned 64-bit fixed point numbers `UFix64` as the type 
     - Indicates how much was withdrawn and from what account the `Vault` is stored in.
       If the `Vault` is not in account storage when the event is emitted,
       `from` will be `nil`.
-    - `pub event TokensWithdrawn(amount: UFix64, from: Address?)`
+    - `access(all) event TokensWithdrawn(amount: UFix64, from: Address?)`
 
 4 - Depositing a specific amount of tokens *from* using the *deposit* function of the recipient's `Vault`
 
 - `Receiver` interface
-    - `pub fun deposit(from: @FungibleToken.Vault)`
+    - `access(all) fun deposit(from: @FungibleToken.Vault)`
     - Conditions
         - `from` balance must be non-zero
         - The resulting balance must be equal to the initial balance + the balance of `from`
@@ -99,7 +99,7 @@ Right now we are using unsigned 64-bit fixed point numbers `UFix64` as the type 
     - Indicates how much was deposited and to what account the `Vault` is stored in.
       If the `Vault` is not in account storage when the event is emitted,
       `to` will be `nil`.
-    - `pub event TokensDeposited(amount: UFix64, to: Address?)`
+    - `access(all) event TokensDeposited(amount: UFix64, to: Address?)`
 - Users could create custom `Receiver`s to trigger special code when transfers to them happen, like forwarding the tokens
   to another account, splitting them up, and much more.
 
@@ -110,7 +110,7 @@ Right now we are using unsigned 64-bit fixed point numbers `UFix64` as the type 
 
 5 - Creating an empty Vault resource
 
-- `pub fun createEmptyVault(): @FungibleToken.Vault`
+- `access(all) fun createEmptyVault(): @FungibleToken.Vault`
 - Defined in the contract 
   To create an empty `Vault`, the caller calls the function in the contract and stores the Vault in their storage.
 - Conditions:

--- a/docs/concepts/token-standards/flow-nft/index.md
+++ b/docs/concepts/token-standards/flow-nft/index.md
@@ -193,7 +193,7 @@ This view is meant to be used by 3rd party marketplaces to take a cut of the pro
 and send it to the author of a certain NFT. Each NFT can have its own royalty view:
 
 ```cadence
-pub struct Royalties {
+access(all) struct Royalties {
 
     /// Array that tracks the individual royalties
     access(self) let cutInfos: [Royalty]
@@ -203,13 +203,13 @@ pub struct Royalties {
 and the royalty can indicate whatever fungible token it wants to accept via the type of the generic `{FungibleToken.Reciever}` capability that it specifies:
 
 ```cadence
-pub struct Royalty {
+access(all) struct Royalty {
     /// Generic FungibleToken Receiver for the beneficiary of the royalty
     /// Can get the concrete type of the receiver with receiver.getType()
     /// Recommendation - Users should create a new link for a FlowToken receiver for this using `getRoyaltyReceiverPublicPath()`,
     /// and not use the default FlowToken receiver.
     /// This will allow users to update the capability in the future to use a more generic capability
-    pub let receiver: Capability<&AnyResource{FungibleToken.Receiver}>
+    access(all) let receiver: Capability<&AnyResource{FungibleToken.Receiver}>
 
     /// Multiplier used to calculate the amount of sale value transferred to royalty receiver.
     /// Note - It should be between 0.0 and 1.0
@@ -219,7 +219,7 @@ pub struct Royalty {
     /// in solidity based smart contracts while cadence offers `UFix64` that already supports
     /// the basis points use case because its operations
     /// are entirely deterministic integer operations and support up to 8 points of precision.
-    pub let cut: UFix64
+    access(all) let cut: UFix64
 }
 ```
 

--- a/docs/tooling/fcl-js/api.md
+++ b/docs/tooling/fcl-js/api.md
@@ -301,7 +301,7 @@ async function myScript () {
     fcl.script`
       import FungibleToken from 0xFungibleToken // will be replaced with 0xf233dcee88fe0abe because of the configuration
 
-      pub fun main() { /* Rest of the script goes here */ }
+      access(all) fun main() { /* Rest of the script goes here */ }
     `
   ]).then(fcl.decode)
 }
@@ -774,7 +774,7 @@ import * as fcl from "@onflow/fcl";
 
 const result = await fcl.query({
   cadence: `
-    pub fun main(a: Int, b: Int, addr: Address): Int {
+    access(all) fun main(a: Int, b: Int, addr: Address): Int {
       log(addr)
       return a + b
     }
@@ -1024,7 +1024,7 @@ import * as fcl from "@onflow/fcl";
 // simple script to add 2 numbers
 const response = await fcl.send([
   fcl.script`
-        pub fun main(int1: Int, int2: Int): Int {
+        access(all) fun main(int1: Int, int2: Int): Int {
             return int1 + int2
         }
     `,
@@ -1443,7 +1443,7 @@ import * as fcl from "@onflow/fcl";
 await fcl
   .send([
     fcl.script`
-      pub fun main(a: Int, b: Int): Int {
+      access(all) fun main(a: Int, b: Int): Int {
         return a + b
       }
     `,
@@ -1481,7 +1481,7 @@ import * as fcl from "@onflow/fcl";
 await fcl
   .send([
     fcl.script`
-      pub fun main(a: Int, b: Int): Int {
+      access(all) fun main(a: Int, b: Int): Int {
         return a + b
       }
     `,
@@ -1523,7 +1523,7 @@ A template builder to use a Cadence script for an interaction.
 import * as fcl from "@onflow/fcl";
 
 const code = `
-  pub fun main(): Int {
+  access(all) fun main(): Int {
     return 5 + 4
   }
 `;
@@ -1559,7 +1559,7 @@ A template builder to use a Cadence transaction for an interaction.
 import * as fcl from "@onflow/fcl";
 
 const code = `
-  pub fun main(): Int {
+  access(all) fun main(): Int {
     return 5 + 4
   }
 `;

--- a/docs/tooling/fcl-js/configure-fcl.mdx
+++ b/docs/tooling/fcl-js/configure-fcl.mdx
@@ -75,7 +75,7 @@ async function myScript () {
     fcl.script`
       import FungibleToken from 0xFungibleToken // will be replaced with 0xf233dcee88fe0abe because of the configuration
 
-      pub fun main() { /* Rest of the script goes here */ }
+      access(all) fun main() { /* Rest of the script goes here */ }
     `
   ]).then(fcl.decode)
 }

--- a/docs/tooling/fcl-js/index.md
+++ b/docs/tooling/fcl-js/index.md
@@ -69,7 +69,7 @@ import * as fcl from "@onflow/fcl";
 
 const result = await fcl.query({
   cadence: `
-    pub fun main(a: Int, b: Int, addr: Address): Int {
+    access(all) fun main(a: Int, b: Int, addr: Address): Int {
       log(addr)
       return a + b
     }

--- a/docs/tooling/fcl-js/index.mdx.txt
+++ b/docs/tooling/fcl-js/index.mdx.txt
@@ -83,7 +83,7 @@ import * as fcl from "@onflow/fcl";
 
 const result = await fcl.query({
   cadence: `
-    pub fun main(a: Int, b: Int, addr: Address): Int {
+    access(all) fun main(a: Int, b: Int, addr: Address): Int {
       log(addr)
       return a + b
     }

--- a/docs/tooling/fcl-js/scripts.mdx
+++ b/docs/tooling/fcl-js/scripts.mdx
@@ -2,7 +2,7 @@
 
 Scripts let you run non-permanent Cadence scripts on the Flow blockchain. They can return data.
 
-They always need to contain a `pub fun main()` function as an entry point to the script.
+They always need to contain a `access(all) fun main()` function as an entry point to the script.
 
 `fcl.query` is a function that sends Cadence scripts to the chain and receives back decoded responses.
 
@@ -18,7 +18,7 @@ import * as fcl from "@onflow/fcl"
 
 const response = await fcl.query({
   cadence: `
-    pub fun main(): Int {
+    access(all) fun main(): Int {
       return 1 + 2
     }
   `
@@ -40,9 +40,9 @@ import * as fcl from "@onflow/fcl"
 
 const response = await fcl.query({
   cadence: `
-    pub struct Point {
-      pub var x: Int
-      pub var y: Int
+    access(all) struct Point {
+      access(all) var x: Int
+      access(all) var y: Int
 
       init(x: Int, y: Int) {
         self.x = x
@@ -50,7 +50,7 @@ const response = await fcl.query({
       }
     }
 
-    pub fun main(): [Point] {
+    access(all) fun main(): [Point] {
       return [Point(x: 1, y: 1), Point(x: 2, y: 2)]
     }
   `
@@ -85,9 +85,9 @@ fcl.config()
 
 const response = await fcl.query({
   cadence: `
-    pub struct Point {
-      pub var x: Int
-      pub var y: Int
+    access(all) struct Point {
+      access(all) var x: Int
+      access(all) var y: Int
 
       init(x: Int, y: Int) {
         self.x = x
@@ -95,7 +95,7 @@ const response = await fcl.query({
       }
     }
 
-    pub fun main(): [Point] {
+    access(all) fun main(): [Point] {
       return [Point(x: 1, y: 1), Point(x: 2, y: 2)]
     }
   `

--- a/docs/tooling/fcl-js/sdk-guidelines.mdx
+++ b/docs/tooling/fcl-js/sdk-guidelines.mdx
@@ -249,7 +249,7 @@ import * as fcl from "@onflow/fcl";
 
 const result = await fcl.query({
   cadence: `
-    pub fun main(a: Int, b: Int, addr: Address): Int {
+    access(all) fun main(a: Int, b: Int, addr: Address): Int {
       log(addr)
       return a + b
     }

--- a/docs/tooling/flow-cadut/api.md
+++ b/docs/tooling/flow-cadut/api.md
@@ -25,7 +25,7 @@ const code = `
   import Message from 0x01
   import Utilities from 0x02
   
-  pub fun main(){
+  access(all) fun main(){
     Utilities.log(Message.hello)
   }
 `;
@@ -67,7 +67,7 @@ const code = `
   import Message from 0x01
   import Utilities from 0x02
   
-  pub fun main(){
+  access(all) fun main(){
     Utilities.log(Message.hello)
   }
 `;
@@ -98,7 +98,7 @@ import { missingImports, report } from '@onflow/flow-cadut';
 const code = `
       import Message from 0x01
       
-      pub fun main(){}
+      access(all) fun main(){}
     `;
 const list = missingImports(code, {});
 report(list);
@@ -128,7 +128,7 @@ import { missingImports, report } from '@onflow/flow-cadut';
 const code = `
   import Message from 0x01
   
-  pub fun main(){}
+  access(all) fun main(){}
 `;
 
 reportMissingImports(code);
@@ -159,7 +159,7 @@ import { replaceImportAddresses } from '@onflow/flow-cadut';
 const code = `
   import Messages from 0x01
   
-  pub fun main(){}
+  access(all) fun main(){}
 `;
 const addressMap = {
   Message: '0xf8d6e0586b0a20c7',
@@ -199,7 +199,7 @@ import { mapArgument } from '@onflow/flow-cadut';
   config().put('accessNode.api', 'https://rest-testnet.onflow.org');
 
   const cadence = `
-    pub fun main(message: String): String{
+    access(all) fun main(message: String): String{
       return message
     }
 `;
@@ -245,7 +245,7 @@ import { mapArgument } from '@onflow/flow-cadut';
   config().put('accessNode.api', 'https://rest-testnet.onflow.org');
 
   const cadence = `
-    pub fun main(message: String, amount: Int): Int{
+    access(all) fun main(message: String, amount: Int): Int{
       log(message)
       return amount
     }
@@ -295,7 +295,7 @@ import { mapValuesToCode } from '@onflow/flow-cadut';
   config().put('accessNode.api', 'https://rest-testnet.onflow.org');
 
   const cadence = `
-    pub fun main(metadata: {String:String}, key: String):String {
+    access(all) fun main(metadata: {String:String}, key: String):String {
       return metadata[key]!
     }
 `;
@@ -331,7 +331,7 @@ Parses the code and returns [TemplateInfo](#TemplateInfo)
 import { getTemplateInfo } from '@onflow/flow-cadut';
 
 const script = `
-  pub fun main(message:String):String{
+  access(all) fun main(message:String):String{
     return 42
   }
 `;
@@ -369,7 +369,7 @@ Parses the code and returns array of [SignerPair](#SignerPair)
 import { extractSigners } from '@onflow/flow-cadut';
 
 const script = `
-  pub fun main(){
+  access(all) fun main(){
     log("nothing to see here :)")
   }
 `;
@@ -399,7 +399,7 @@ Parses the code and returns array of [ArgumentPair](#ArgumentPair)
 import { extractScriptArguments } from '@onflow/flow-cadut';
 
 const script = `
-  pub fun main(message: String, metadata: {String:String}){
+  access(all) fun main(message: String, metadata: {String:String}){
     log(message)
   }
 `;
@@ -461,7 +461,7 @@ Parses the code and returns contract name
 import { extractContractName } from '@onflow/flow-cadut';
 
 const contract = `
-  pub contract HelloWorld{
+  access(all) contract HelloWorld{
     init(){}
   }
 `;
@@ -739,7 +739,7 @@ Syntax sugar for `Buffer.from(code, "utf8").toString("hex");`
 import { hexContract } from '@onflow/flow-cadut';
 
 const code = `
-  pub contract HelloWorld{
+  access(all) contract HelloWorld{
     init(){}
   }
 `;
@@ -787,7 +787,7 @@ import { executeScript } from '@onflow/flow-cadut';
 
 (async () => {
   const code = `
-    pub fun main():Int{
+    access(all) fun main():Int{
       return 42
     }
   `;

--- a/docs/tooling/flow-cadut/generator.md
+++ b/docs/tooling/flow-cadut/generator.md
@@ -66,7 +66,7 @@ const content = readFile("./log.cdc");
 import { writeFile } from "@onflow/flow-cadut";
 
 const script = `
-  pub fun main(){
+  access(all) fun main(){
     log("Hello, Cadence")
   }
 `;

--- a/docs/tooling/flow-cli/accounts/account-add-contract.md
+++ b/docs/tooling/flow-cli/accounts/account-add-contract.md
@@ -91,7 +91,7 @@ Example:
 ```
 Transaction code:
 ```
-pub contract HelloWorld {
+access(all) contract HelloWorld {
     init(a:String, b:Int) {
     }
 }

--- a/docs/tooling/flow-cli/accounts/account-update-contract.md
+++ b/docs/tooling/flow-cli/accounts/account-update-contract.md
@@ -89,7 +89,7 @@ Example:
 ```
 Transaction code:
 ```
-pub contract HelloWorld {
+access(all) contract HelloWorld {
     init(a:String, b:Int) {
     }
 }

--- a/docs/tooling/flow-cli/deployment/deploy-project-contracts.md
+++ b/docs/tooling/flow-cli/deployment/deploy-project-contracts.md
@@ -49,7 +49,7 @@ In the example above, your `flow.json` file might look something like this:
 Here's a sketch of the contract source files:
 
 ```cadence NonFungibleToken.cdc
-pub contract NonFungibleToken { 
+access(all) contract NonFungibleToken { 
   // ...
 }
 ```
@@ -57,7 +57,7 @@ pub contract NonFungibleToken {
 ```cadence KittyItems.cdc
 import NonFungibleToken from "./NonFungibleToken.cdc"
 
-pub contract KittyItems { 
+access(all) contract KittyItems { 
   // ...
 }
 ```
@@ -116,7 +116,7 @@ In the example above, the `KittyItems` contract would be rewritten like this:
 ```cadence KittyItems.cdc
 import NonFungibleToken from 0xf8d6e0586b0a20c7
 
-pub contract KittyItems { 
+access(all) contract KittyItems { 
   // ...
 }
 ```

--- a/docs/tooling/flow-cli/developer-updates/release-notes-v17.md
+++ b/docs/tooling/flow-cli/developer-updates/release-notes-v17.md
@@ -116,8 +116,8 @@ Key 0   Public Key               c8a2a318b9099cc6...a0fe320dba7
         Hash Algorithm           SHA3_256
 
 Code             
-         pub contract Foo {
-                pub var bar: String
+         access(all) contract Foo {
+                access(all) var bar: String
          
                 init() {
                         self.bar = "Hello, World!"

--- a/docs/tooling/flow-cli/developer-updates/release-notes-v18.md
+++ b/docs/tooling/flow-cli/developer-updates/release-notes-v18.md
@@ -15,7 +15,7 @@ Example script: `get_supply.cdc`
 ```
 import Kibble from "../../../contracts/Kibble.cdc"
 
-pub fun main(): UFix64 {
+access(all) fun main(): UFix64 {
     let supply = Kibble.totalSupply
     return supply
 }

--- a/docs/tooling/flow-cli/execute-scripts.md
+++ b/docs/tooling/flow-cli/execute-scripts.md
@@ -23,7 +23,7 @@ flow scripts execute <filename> [<argument> <argument>...] [flags]
 
 Script source code:
 ```
-pub fun main(greeting: String, who: String): String {
+access(all) fun main(greeting: String, who: String): String {
 	return greeting.concat(" ").concat(who)
 }
 ```

--- a/docs/tooling/flow-cli/run-tests.md
+++ b/docs/tooling/flow-cli/run-tests.md
@@ -19,10 +19,10 @@ A simple Cadence script `test_script.cdc`, which has a test case for running a c
 ```cadence
 import Test
 
-pub fun testSimpleScript() {
+access(all) fun testSimpleScript() {
     var blockchain = Test.newEmulatorBlockchain()
     var result = blockchain.executeScript(
-        "pub fun main(a: Int, b: Int): Int { return a + b }",
+        "access(all) fun main(a: Int, b: Int): Int { return a + b }",
         [2, 3]
     )
     

--- a/docs/tooling/flow-go-sdk/index.mdx
+++ b/docs/tooling/flow-go-sdk/index.mdx
@@ -425,7 +425,7 @@ func demo() {
     flowClient := examples.NewFlowClient()
 
     script := []byte(`
-        pub fun main(a: Int): Int {
+        access(all) fun main(a: Int): Int {
             return a + 10
         }
     `)
@@ -436,10 +436,10 @@ func demo() {
     fmt.Printf("\nValue: %s", value.String())
 
     complexScript := []byte(`
-        pub struct User {
-            pub var balance: UFix64
-            pub var address: Address
-            pub var name: String
+        access(all) struct User {
+            access(all) var balance: UFix64
+            access(all) var address: Address
+            access(all) var name: String
 
             init(name: String, address: Address, balance: UFix64) {
                 self.name = name
@@ -448,7 +448,7 @@ func demo() {
             }
         }
 
-        pub fun main(name: String): User {
+        access(all) fun main(name: String): User {
             return User(
                 name: name,
                 address: 0x1,

--- a/docs/tooling/flow-js-testing/api.md
+++ b/docs/tooling/flow-js-testing/api.md
@@ -163,8 +163,8 @@ import {
 
   const name = "Wallet"
   const code = `
-        pub contract Wallet{
-            pub let balance: UInt
+        access(all) contract Wallet{
+            access(all) let balance: UInt
             init(balance: UInt){
               self.balance = balance
             }
@@ -177,7 +177,7 @@ import {
   const [balance, err] = await executeScript({
     code: `
       import Wallet from 0x01
-      pub fun main(): UInt{
+      access(all) fun main(): UInt{
         return Wallet.balance
       }
     `,
@@ -692,7 +692,7 @@ const main = async () => {
 
   // "getCurrentBlock().height" in your Cadence code will be replaced by Manager to a mocked value
   const code = `
-    pub fun main(): UInt64 {
+    access(all) fun main(): UInt64 {
       return getCurrentBlock().height
     }
   `
@@ -779,7 +779,7 @@ const main = async () => {
 
   // "getCurrentBlock().timestamp" in your Cadence code will be replaced by Manager to a mocked value
   const code = `
-    pub fun main(): UInt64 {
+    access(all) fun main(): UInt64 {
       return getCurrentBlock().timestamp
     }
   `
@@ -991,7 +991,7 @@ describe("interactions - sendTransaction", () => {
 
   test("basic script", async () => {
     const code = `
-      pub fun main():Int{
+      access(all) fun main():Int{
         return 42
       }
     `
@@ -1057,7 +1057,7 @@ const main = async () => {
 
   // Define code and arguments we want to pass
   const code = `
-    pub fun main(message: String): Int{
+    access(all) fun main(message: String): Int{
       log(message)
 
       return 42

--- a/docs/tooling/flow-js-testing/contracts.md
+++ b/docs/tooling/flow-js-testing/contracts.md
@@ -110,8 +110,8 @@ import {
 
   const name = "Wallet"
   const code = `
-        pub contract Wallet{
-            pub let balance: UInt
+        access(all) contract Wallet{
+            access(all) let balance: UInt
             init(balance: UInt){
               self.balance = balance
             }
@@ -124,7 +124,7 @@ import {
   const [balance, err] = await executeScript({
     code: `
       import Wallet from 0x01
-      pub fun main(): UInt{
+      access(all) fun main(): UInt{
         return Wallet.balance
       }
     `,

--- a/docs/tooling/flow-js-testing/examples/metadata.md
+++ b/docs/tooling/flow-js-testing/examples/metadata.md
@@ -21,7 +21,7 @@ const main = async () => {
   await emulator.start()
 
   const code = `
-    pub fun main(metadata: {String: String}): String{
+    access(all) fun main(metadata: {String: String}): String{
       return metadata["name"]!
     }  
   `

--- a/docs/tooling/flow-js-testing/execute-scripts.md
+++ b/docs/tooling/flow-js-testing/execute-scripts.md
@@ -51,7 +51,7 @@ const main = async () => {
 
   // Define code and arguments we want to pass
   const code = `
-    pub fun main(message: String): Int{
+    access(all) fun main(message: String): Int{
       log(message)
 
       return 42

--- a/docs/tooling/flow-js-testing/jest-helpers.md
+++ b/docs/tooling/flow-js-testing/jest-helpers.md
@@ -189,7 +189,7 @@ describe("interactions - sendTransaction", () => {
 
   test("basic script", async () => {
     const code = `
-      pub fun main():Int{
+      access(all) fun main():Int{
         return 42
       }
     `

--- a/docs/tooling/nft-catalog/composability-flowcase-guide.mdx
+++ b/docs/tooling/nft-catalog/composability-flowcase-guide.mdx
@@ -59,9 +59,9 @@ Our showcase will serve as a read-only grouping of NFTs stored in a user’s Flo
 Below the comment that says `Structs and Resources`, we can implement our `Showcase` and `NFTPointer` like the following:
 
 ```go
-pub struct NFTPointer {
-    pub let id: UInt64
-    pub let collection: Capability<&{NonFungibleToken.CollectionPublic}>
+access(all) struct NFTPointer {
+    access(all) let id: UInt64
+    access(all) let collection: Capability<&{NonFungibleToken.CollectionPublic}>
 
     init(id: UInt64, collection: Capability<&{NonFungibleToken.CollectionPublic}>) {
         self.id = id
@@ -69,16 +69,16 @@ pub struct NFTPointer {
     }
 }
 
-pub struct Showcase {
-    pub let name: String
-    priv let nfts: [NFTPointer]
+access(all) struct Showcase {
+    access(all) let name: String
+    access(self) let nfts: [NFTPointer]
 
     init(name: String, nfts: [NFTPointer]) {
         self.name = name
         self.nfts = nfts
     }
 
-    pub fun getNFTs(): [NFTPointer] {
+    access(all) fun getNFTs(): [NFTPointer] {
         return self.nfts
     }
 }
@@ -101,40 +101,40 @@ The `ShowcaseCollection` resource has a similar implementation to an NFT collect
 Here is the code for the `ShowcaseCollection` resource:
 
 ```go
-pub event ShowcaseAdded(name: String, to: Address?)
-pub event ShowcaseRemoved(name: String)
+access(all) event ShowcaseAdded(name: String, to: Address?)
+access(all) event ShowcaseRemoved(name: String)
 
-pub resource interface ShowcaseCollectionPublic {
-    pub fun getShowcases(): {String: Showcase}
-    pub fun getShowcase(name: String): Showcase?
+access(all) resource interface ShowcaseCollectionPublic {
+    access(all) fun getShowcases(): {String: Showcase}
+    access(all) fun getShowcase(name: String): Showcase?
 }
 
-pub resource ShowcaseCollection: ShowcaseCollectionPublic {
-    pub let showcases: {String: Showcase}
+access(all) resource ShowcaseCollection: ShowcaseCollectionPublic {
+    access(all) let showcases: {String: Showcase}
 
     init() {
         self.showcases = {}
     }
 
-    pub fun addShowcase(name: String, nfts: [NFTPointer]) {
+    access(all) fun addShowcase(name: String, nfts: [NFTPointer]) {
         emit ShowcaseAdded(name: name, to: self.owner?.address)
         self.showcases[name] = Showcase(name: name, nfts: nfts)
     }
 
-    pub fun removeShowcase(name: String) {
+    access(all) fun removeShowcase(name: String) {
         self.showcases.remove(key: name)
     }
 
-    pub fun getShowcases(): {String: Showcase} {
+    access(all) fun getShowcases(): {String: Showcase} {
         return self.showcases
     }
 
-    pub fun getShowcase(name: String): Showcase? {
+    access(all) fun getShowcase(name: String): Showcase? {
         return self.showcases[name]
     }
 }
 
-pub fun createShowcaseCollection(): @ShowcaseCollection {
+access(all) fun createShowcaseCollection(): @ShowcaseCollection {
     return <-create ShowcaseCollection()
 }
 ```
@@ -268,7 +268,7 @@ import NonFungibleToken from 0xNONFUNGIBLETOKENADDRESS
 import MetadataViews from 0xMETADATAVIEWSADDRESS
 import Flowcase from 0xFLOWCASEADDRESS
 
-pub fun main(address: Address): {String: [AnyStruct]}? {
+access(all) fun main(address: Address): {String: [AnyStruct]}? {
     let account = getAccount(address)
     var nfts: [AnyStruct] = []
     let flowcaseCap = account.getCapability<&{Flowcase.ShowcaseCollectionPublic}>(/public/flowcaseCollection)

--- a/docs/tooling/nft-catalog/composability-nft-guide.mdx
+++ b/docs/tooling/nft-catalog/composability-nft-guide.mdx
@@ -44,25 +44,25 @@ Let’s start with a basic NFT
 ```go
 import NonFungibleToken from "./NonFungibleToken.cdc"
 
-pub contract MyFunNFT: NonFungibleToken {
+access(all) contract MyFunNFT: NonFungibleToken {
 
-    pub event ContractInitialized()
-    pub event Withdraw(id: UInt64, from: Address?)
-    pub event Deposit(id: UInt64, to: Address?)
-    pub event Minted(id: UInt64, editionID: UInt64, serialNumber: UInt64)
-    pub event Burned(id: UInt64)
+    access(all) event ContractInitialized()
+    access(all) event Withdraw(id: UInt64, from: Address?)
+    access(all) event Deposit(id: UInt64, to: Address?)
+    access(all) event Minted(id: UInt64, editionID: UInt64, serialNumber: UInt64)
+    access(all) event Burned(id: UInt64)
 
-    pub let CollectionStoragePath: StoragePath
-    pub let CollectionPublicPath: PublicPath
-    pub let CollectionPrivatePath: PrivatePath
+    access(all) let CollectionStoragePath: StoragePath
+    access(all) let CollectionPublicPath: PublicPath
+    access(all) let CollectionPrivatePath: PrivatePath
 
     /// The total number of NFTs that have been minted.
     ///
-    pub var totalSupply: UInt64
+    access(all) var totalSupply: UInt64
 
-    pub resource NFT: NonFungibleToken.INFT {
+    access(all) resource NFT: NonFungibleToken.INFT {
 
-        pub let id: UInt64
+        access(all) let id: UInt64
 
         init(
         ) {
@@ -77,11 +77,11 @@ pub contract MyFunNFT: NonFungibleToken {
     }
 
 
-     pub resource interface MyFunNFTCollectionPublic {
-        pub fun deposit(token: @NonFungibleToken.NFT)
-        pub fun getIDs(): [UInt64]
-        pub fun borrowNFT(id: UInt64): &NonFungibleToken.NFT
-        pub fun borrowMyFunNFT(id: UInt64): &MyFunNFT.NFT? {
+     access(all) resource interface MyFunNFTCollectionPublic {
+        access(all) fun deposit(token: @NonFungibleToken.NFT)
+        access(all) fun getIDs(): [UInt64]
+        access(all) fun borrowNFT(id: UInt64): &NonFungibleToken.NFT
+        access(all) fun borrowMyFunNFT(id: UInt64): &MyFunNFT.NFT? {
             post {
                 (result == nil) || (result?.id == id):
                     "Cannot borrow MyFunNFT reference: The ID of the returned reference is incorrect"
@@ -89,11 +89,11 @@ pub contract MyFunNFT: NonFungibleToken {
         }
     }
 
-    pub resource Collection: MyFunNFTCollectionPublic, NonFungibleToken.Provider, NonFungibleToken.Receiver, NonFungibleToken.CollectionPublic {
+    access(all) resource Collection: MyFunNFTCollectionPublic, NonFungibleToken.Provider, NonFungibleToken.Receiver, NonFungibleToken.CollectionPublic {
 
         /// A dictionary of all NFTs in this collection indexed by ID.
         ///
-        pub var ownedNFTs: @{UInt64: NonFungibleToken.NFT}
+        access(all) var ownedNFTs: @{UInt64: NonFungibleToken.NFT}
 
         init () {
             self.ownedNFTs <- {}
@@ -101,7 +101,7 @@ pub contract MyFunNFT: NonFungibleToken {
 
         /// Remove an NFT from the collection and move it to the caller.
         ///
-        pub fun withdraw(withdrawID: UInt64): @NonFungibleToken.NFT {
+        access(all) fun withdraw(withdrawID: UInt64): @NonFungibleToken.NFT {
             let token <- self.ownedNFTs.remove(key: withdrawID)
                 ?? panic("Requested NFT to withdraw does not exist in this collection")
 
@@ -112,7 +112,7 @@ pub contract MyFunNFT: NonFungibleToken {
 
         /// Deposit an NFT into this collection.
         ///
-        pub fun deposit(token: @NonFungibleToken.NFT) {
+        access(all) fun deposit(token: @NonFungibleToken.NFT) {
             let token <- token as! @MyFunNFT.NFT
 
             let id: UInt64 = token.id
@@ -127,7 +127,7 @@ pub contract MyFunNFT: NonFungibleToken {
 
         /// Return an array of the NFT IDs in this collection.
         ///
-        pub fun getIDs(): [UInt64] {
+        access(all) fun getIDs(): [UInt64] {
             return self.ownedNFTs.keys
         }
 
@@ -135,7 +135,7 @@ pub contract MyFunNFT: NonFungibleToken {
         ///
         /// This function panics if the NFT does not exist in this collection.
         ///
-        pub fun borrowNFT(id: UInt64): &NonFungibleToken.NFT {
+        access(all) fun borrowNFT(id: UInt64): &NonFungibleToken.NFT {
             return (&self.ownedNFTs[id] as &NonFungibleToken.NFT?)!
         }
 
@@ -144,7 +144,7 @@ pub contract MyFunNFT: NonFungibleToken {
         ///
         /// This function returns nil if the NFT does not exist in this collection.
         ///
-        pub fun borrowMyFunNFT(id: UInt64): &MyFunNFT.NFT? {
+        access(all) fun borrowMyFunNFT(id: UInt64): &MyFunNFT.NFT? {
             if self.ownedNFTs[id] != nil {
                 let ref = (&self.ownedNFTs[id] as auth &NonFungibleToken.NFT?)!
                 return ref as! &MyFunNFT.NFT
@@ -158,7 +158,7 @@ pub contract MyFunNFT: NonFungibleToken {
         }
     }
 
-    pub fun mintNFT(): @MyFunNFT.NFT {
+    access(all) fun mintNFT(): @MyFunNFT.NFT {
             let nft <- create MyFunNFT.NFT()
 
             MyFunNFT.totalSupply = MyFunNFT.totalSupply + (1 as UInt64)
@@ -166,7 +166,7 @@ pub contract MyFunNFT: NonFungibleToken {
             return <- nft
     }
 
-    pub fun createEmptyCollection(): @NonFungibleToken.Collection {
+    access(all) fun createEmptyCollection(): @NonFungibleToken.Collection {
         return <- create Collection()
     }
 
@@ -189,7 +189,7 @@ Although this is commendable progress, the current NFT implementation lacks data
 Firstly, we will introduce two global variables at the top of the code, alongside `totalSupply`:
 
 ```go
-pub var totalEditions: UInt64
+access(all) var totalEditions: UInt64
 
 access(self) let editions: {UInt64: Edition}
 ```
@@ -221,28 +221,28 @@ init() {
 These variables will facilitate monitoring the overall count of editions and accessing a specific edition through its assigned identifier. The `editions`dictionary will provide a means to extract particular information for each edition. Consequently, we will proceed to construct the `Edition`struct that we refer to within our `editions`object.
 
 ```go
-pub struct Edition {
+access(all) struct Edition {
 
-        pub let id: UInt64
+        access(all) let id: UInt64
 
         /// The number of NFTs minted in this edition.
         ///
         /// This field is incremented each time a new NFT is minted.
         ///
-        pub var size: UInt64
+        access(all) var size: UInt64
 
         /// The number of NFTs in this edition that have been burned.
         ///
         /// This field is incremented each time an NFT is burned.
         ///
-        pub var burned: UInt64
+        access(all) var burned: UInt64
 
-        pub fun supply(): UInt64 {
+        access(all) fun supply(): UInt64 {
             return self.size - self.burned
         }
 
         /// The metadata for this edition.
-        pub let metadata: Metadata
+        access(all) let metadata: Metadata
 
         init(
             id: UInt64,
@@ -273,10 +273,10 @@ pub struct Edition {
 This is a fundamental struct that we will employ to represent "Editions" within this NFT. It retains an `id`, the `size`, the `burned` count, and a bespoke `Metadata`object defined below. Please include this struct in your code as well.
 
 ```go
-pub struct Metadata {
+access(all) struct Metadata {
 
-        pub let name: String
-        pub let description: String
+        access(all) let name: String
+        access(all) let description: String
 
         init(
             name: String,
@@ -295,8 +295,8 @@ We will now proceed to modify the NFT resource to include additional fields that
 Add the following fields below `id` in the NFT resource:
 
 ```go
-pub let editionID: UInt64
-pub let serialNumber: UInt64
+access(all) let editionID: UInt64
+access(all) let serialNumber: UInt64
 ```
 
 Update the `init()` function in the NFT resource:
@@ -315,7 +315,7 @@ init(
 Update the `mintNFT()` function to adhere to the new `init()` and the `Edition` struct:
 
 ```go
-pub fun mintNFT(editionID: UInt64): @MyFunNFT.NFT {
+access(all) fun mintNFT(editionID: UInt64): @MyFunNFT.NFT {
             let edition = MyFunNFT.editions[editionID]
                 ?? panic("edition does not exist")
 
@@ -341,7 +341,7 @@ Excellent progress! We can now mint new NFTs for a specific edition. However, we
 
 ```go
 
-pub fun createEdition(
+access(all) fun createEdition(
             name: String,
             description: String,
         ): UInt64 {
@@ -365,7 +365,7 @@ pub fun createEdition(
             return edition.id
 }
 
-pub fun getEdition(id: UInt64): Edition? {
+access(all) fun getEdition(id: UInt64): Edition? {
         return MyFunNFT.editions[id]
 }
 
@@ -376,12 +376,12 @@ followed by adding the getEdition helper method.
 Let’s also add the new event:
 
 ```
-pub event ContractInitialized()
-pub event Withdraw(id: UInt64, from: Address?)
-pub event Deposit(id: UInt64, to: Address?)
-pub event Minted(id: UInt64, editionID: UInt64, serialNumber: UInt64)
-pub event Burned(id: UInt64)
-pub event EditionCreated(edition: Edition)
+access(all) event ContractInitialized()
+access(all) event Withdraw(id: UInt64, from: Address?)
+access(all) event Deposit(id: UInt64, to: Address?)
+access(all) event Minted(id: UInt64, editionID: UInt64, serialNumber: UInt64)
+access(all) event Burned(id: UInt64)
+access(all) event EditionCreated(edition: Edition)
 ```
 
 Your NFT should look something like this:
@@ -389,31 +389,31 @@ Your NFT should look something like this:
 ```go
 import NonFungibleToken from "./NonFungibleToken.cdc"
 
-pub contract MyFunNFT: NonFungibleToken {
+access(all) contract MyFunNFT: NonFungibleToken {
 
-    pub event ContractInitialized()
-    pub event Withdraw(id: UInt64, from: Address?)
-    pub event Deposit(id: UInt64, to: Address?)
-    pub event Minted(id: UInt64, editionID: UInt64, serialNumber: UInt64)
-    pub event Burned(id: UInt64)
-    pub event EditionCreated(edition: Edition)
+    access(all) event ContractInitialized()
+    access(all) event Withdraw(id: UInt64, from: Address?)
+    access(all) event Deposit(id: UInt64, to: Address?)
+    access(all) event Minted(id: UInt64, editionID: UInt64, serialNumber: UInt64)
+    access(all) event Burned(id: UInt64)
+    access(all) event EditionCreated(edition: Edition)
 
-    pub let CollectionStoragePath: StoragePath
-    pub let CollectionPublicPath: PublicPath
-    pub let CollectionPrivatePath: PrivatePath
+    access(all) let CollectionStoragePath: StoragePath
+    access(all) let CollectionPublicPath: PublicPath
+    access(all) let CollectionPrivatePath: PrivatePath
 
     /// The total number of NFTs that have been minted.
     ///
-    pub var totalSupply: UInt64
+    access(all) var totalSupply: UInt64
 
-    pub var totalEditions: UInt64
+    access(all) var totalEditions: UInt64
 
     access(self) let editions: {UInt64: Edition}
 
-    pub struct Metadata {
+    access(all) struct Metadata {
 
-        pub let name: String
-        pub let description: String
+        access(all) let name: String
+        access(all) let description: String
 
         init(
             name: String,
@@ -424,28 +424,28 @@ pub contract MyFunNFT: NonFungibleToken {
         }
     }
 
-    pub struct Edition {
+    access(all) struct Edition {
 
-        pub let id: UInt64
+        access(all) let id: UInt64
 
         /// The number of NFTs minted in this edition.
         ///
         /// This field is incremented each time a new NFT is minted.
         ///
-        pub var size: UInt64
+        access(all) var size: UInt64
 
         /// The number of NFTs in this edition that have been burned.
         ///
         /// This field is incremented each time an NFT is burned.
         ///
-        pub var burned: UInt64
+        access(all) var burned: UInt64
 
-        pub fun supply(): UInt64 {
+        access(all) fun supply(): UInt64 {
             return self.size - self.burned
         }
 
         /// The metadata for this edition.
-        pub let metadata: Metadata
+        access(all) let metadata: Metadata
 
         init(
             id: UInt64,
@@ -472,12 +472,12 @@ pub contract MyFunNFT: NonFungibleToken {
         }
     }
 
-    pub resource NFT: NonFungibleToken.INFT {
+    access(all) resource NFT: NonFungibleToken.INFT {
 
-        pub let id: UInt64
+        access(all) let id: UInt64
 
-        pub let editionID: UInt64
-        pub let serialNumber: UInt64
+        access(all) let editionID: UInt64
+        access(all) let serialNumber: UInt64
 
         init(
             editionID: UInt64,
@@ -496,11 +496,11 @@ pub contract MyFunNFT: NonFungibleToken {
     }
 
 
-     pub resource interface MyFunNFTCollectionPublic {
-        pub fun deposit(token: @NonFungibleToken.NFT)
-        pub fun getIDs(): [UInt64]
-        pub fun borrowNFT(id: UInt64): &NonFungibleToken.NFT
-        pub fun borrowMyFunNFT(id: UInt64): &MyFunNFT.NFT? {
+     access(all) resource interface MyFunNFTCollectionPublic {
+        access(all) fun deposit(token: @NonFungibleToken.NFT)
+        access(all) fun getIDs(): [UInt64]
+        access(all) fun borrowNFT(id: UInt64): &NonFungibleToken.NFT
+        access(all) fun borrowMyFunNFT(id: UInt64): &MyFunNFT.NFT? {
             post {
                 (result == nil) || (result?.id == id):
                     "Cannot borrow MyFunNFT reference: The ID of the returned reference is incorrect"
@@ -508,11 +508,11 @@ pub contract MyFunNFT: NonFungibleToken {
         }
     }
 
-    pub resource Collection: MyFunNFTCollectionPublic, NonFungibleToken.Provider, NonFungibleToken.Receiver, NonFungibleToken.CollectionPublic {
+    access(all) resource Collection: MyFunNFTCollectionPublic, NonFungibleToken.Provider, NonFungibleToken.Receiver, NonFungibleToken.CollectionPublic {
 
         /// A dictionary of all NFTs in this collection indexed by ID.
         ///
-        pub var ownedNFTs: @{UInt64: NonFungibleToken.NFT}
+        access(all) var ownedNFTs: @{UInt64: NonFungibleToken.NFT}
 
         init () {
             self.ownedNFTs <- {}
@@ -520,7 +520,7 @@ pub contract MyFunNFT: NonFungibleToken {
 
         /// Remove an NFT from the collection and move it to the caller.
         ///
-        pub fun withdraw(withdrawID: UInt64): @NonFungibleToken.NFT {
+        access(all) fun withdraw(withdrawID: UInt64): @NonFungibleToken.NFT {
             let token <- self.ownedNFTs.remove(key: withdrawID)
                 ?? panic("Requested NFT to withdraw does not exist in this collection")
 
@@ -531,7 +531,7 @@ pub contract MyFunNFT: NonFungibleToken {
 
         /// Deposit an NFT into this collection.
         ///
-        pub fun deposit(token: @NonFungibleToken.NFT) {
+        access(all) fun deposit(token: @NonFungibleToken.NFT) {
             let token <- token as! @MyFunNFT.NFT
 
             let id: UInt64 = token.id
@@ -546,7 +546,7 @@ pub contract MyFunNFT: NonFungibleToken {
 
         /// Return an array of the NFT IDs in this collection.
         ///
-        pub fun getIDs(): [UInt64] {
+        access(all) fun getIDs(): [UInt64] {
             return self.ownedNFTs.keys
         }
 
@@ -554,7 +554,7 @@ pub contract MyFunNFT: NonFungibleToken {
         ///
         /// This function panics if the NFT does not exist in this collection.
         ///
-        pub fun borrowNFT(id: UInt64): &NonFungibleToken.NFT {
+        access(all) fun borrowNFT(id: UInt64): &NonFungibleToken.NFT {
             return (&self.ownedNFTs[id] as &NonFungibleToken.NFT?)!
         }
 
@@ -563,7 +563,7 @@ pub contract MyFunNFT: NonFungibleToken {
         ///
         /// This function returns nil if the NFT does not exist in this collection.
         ///
-        pub fun borrowMyFunNFT(id: UInt64): &MyFunNFT.NFT? {
+        access(all) fun borrowMyFunNFT(id: UInt64): &MyFunNFT.NFT? {
             if self.ownedNFTs[id] != nil {
                 let ref = (&self.ownedNFTs[id] as auth &NonFungibleToken.NFT?)!
                 return ref as! &MyFunNFT.NFT
@@ -577,7 +577,7 @@ pub contract MyFunNFT: NonFungibleToken {
         }
     }
 
-    pub fun createEdition(
+    access(all) fun createEdition(
             name: String,
             description: String,
         ): UInt64 {
@@ -601,7 +601,7 @@ pub contract MyFunNFT: NonFungibleToken {
             return edition.id
     }
 
-    pub fun mintNFT(editionID: UInt64): @MyFunNFT.NFT {
+    access(all) fun mintNFT(editionID: UInt64): @MyFunNFT.NFT {
             let edition = MyFunNFT.editions[editionID]
                 ?? panic("edition does not exist")
 
@@ -620,7 +620,7 @@ pub contract MyFunNFT: NonFungibleToken {
             return <- nft
     }
 
-    pub fun createEmptyCollection(): @NonFungibleToken.Collection {
+    access(all) fun createEmptyCollection(): @NonFungibleToken.Collection {
         return <- create Collection()
     }
 
@@ -720,7 +720,7 @@ Let’s start off by importing the MetadataViews contract to the top
 
 Now we need to have our NFT resource extend the `MetadataViews.Resolver` interface.
 
-`pub resource NFT: NonFungibleToken.INFT, MetadataViews.Resolver`
+`access(all) resource NFT: NonFungibleToken.INFT, MetadataViews.Resolver`
 
 Now we must implement `getViews` and `resolveView`. The function `getViews` tells anyone which views this NFT supports and `resolveView` takes in a view type and returns the view itself. Some common views are:
 
@@ -737,7 +737,7 @@ _NFT Collection Display View_ - How to display the NFT collection on a website
 Let’s add the following `getViews` implementation to our `NFT` resource.
 
 ```go
-pub fun getViews(): [Type] {
+access(all) fun getViews(): [Type] {
             let views = [
                 Type<MetadataViews.Display>(),
                 Type<MetadataViews.ExternalURL>(),
@@ -755,7 +755,7 @@ pub fun getViews(): [Type] {
 These function helps inform what specific views this NFT supports. In the same NFT resource add the following method:
 
 ```go
-pub fun resolveView(_ view: Type): AnyStruct? {
+access(all) fun resolveView(_ view: Type): AnyStruct? {
             let edition = self.getEdition()
 
             switch view {
@@ -782,7 +782,7 @@ pub fun resolveView(_ view: Type): AnyStruct? {
 Now lets go over each individual helper function that you should add to your NFT resource
 
 ```go
-pub fun resolveDisplay(_ metadata: Metadata): MetadataViews.Display {
+access(all) fun resolveDisplay(_ metadata: Metadata): MetadataViews.Display {
             return MetadataViews.Display(
                 name: metadata.name,
                 description: metadata.description,
@@ -794,7 +794,7 @@ pub fun resolveDisplay(_ metadata: Metadata): MetadataViews.Display {
 1\. This creates a display view and takes in the edition data to populate the name and description. I included a dummy image but you would want to include a unique thumbnail
 
 ```go
-pub fun resolveExternalURL(): MetadataViews.ExternalURL {
+access(all) fun resolveExternalURL(): MetadataViews.ExternalURL {
             let collectionURL = "www.flow-nft-catalog.com"
             return MetadataViews.ExternalURL(collectionURL)
 }
@@ -803,7 +803,7 @@ pub fun resolveExternalURL(): MetadataViews.ExternalURL {
 2\. This is a link for the NFT. I’m putting in a placeholder site for now but this would be something for a specific NFT not an entire collection. So something like www.collection_site/nft_id
 
 ```go
-pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+access(all) fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
             let media = MetadataViews.Media(
                 file: MetadataViews.HTTPFile(url: "https://assets-global.website-files.com/5f734f4dbd95382f4fdfa0ea/63ce603ae36f46f6bb67e51e_flow-logo.svg"),
                 mediaType: "image"
@@ -823,7 +823,7 @@ pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
 3\. This is a view that indicates to apps on how to display information about the collection. The externalURL here would be the website for the entire collection. I have linked a temporary flow image but you could many image you want here.
 
 ```go
-pub fun resolveNFTCollectionData(): MetadataViews.NFTCollectionData {
+access(all) fun resolveNFTCollectionData(): MetadataViews.NFTCollectionData {
             return MetadataViews.NFTCollectionData(
                 storagePath: MyFunNFT.CollectionStoragePath,
                 publicPath: MyFunNFT.CollectionPublicPath,
@@ -841,7 +841,7 @@ pub fun resolveNFTCollectionData(): MetadataViews.NFTCollectionData {
 4\. This is a view that allows any Flow Dapps to have the information needed to setup a collection in any users account to support this NFT.
 
 ```go
-pub fun resolveRoyalties(): MetadataViews.Royalties {
+access(all) fun resolveRoyalties(): MetadataViews.Royalties {
             return MetadataViews.Royalties([])
 }
 ```
@@ -849,7 +849,7 @@ pub fun resolveRoyalties(): MetadataViews.Royalties {
 5\. For now we will skip Royalties but here you can specify which addresses should receive royalties and how much.
 
 ```go
-pub fun resolveEditionView(serialNumber: UInt64, size: UInt64): MetadataViews.Edition {
+access(all) fun resolveEditionView(serialNumber: UInt64, size: UInt64): MetadataViews.Edition {
             return MetadataViews.Edition(
                 name: "Edition",
                 number: serialNumber,
@@ -857,7 +857,7 @@ pub fun resolveEditionView(serialNumber: UInt64, size: UInt64): MetadataViews.Ed
             )
 }
 
-pub fun resolveSerialView(serialNumber: UInt64): MetadataViews.Serial {
+access(all) fun resolveSerialView(serialNumber: UInt64): MetadataViews.Serial {
     return MetadataViews.Serial(serialNumber)
 }
 ```
@@ -867,13 +867,13 @@ pub fun resolveSerialView(serialNumber: UInt64): MetadataViews.Serial {
 Lastly we need our `Collection` resource to support `MetadataViews.ResolverCollection`
 
 ```go
-pub resource Collection: MyFunNFTCollectionPublic, NonFungibleToken.Provider, NonFungibleToken.Receiver, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection
+access(all) resource Collection: MyFunNFTCollectionPublic, NonFungibleToken.Provider, NonFungibleToken.Receiver, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection
 ```
 
 You should see an error that you need to implement `borrowViewResolver`. This is a method a Dapp can use on the collection to borrow an NFT that inherits to the `MetadataViews.Resolver` interface so that `resolveView` that we implemented earlier can be called.
 
 ```go
-pub fun borrowViewResolver(id: UInt64): &AnyResource{MetadataViews.Resolver} {
+access(all) fun borrowViewResolver(id: UInt64): &AnyResource{MetadataViews.Resolver} {
             let nft = (&self.ownedNFTs[id] as auth &NonFungibleToken.NFT?)!
             let nftRef = nft as! &MyFunNFT.NFT
             return nftRef as &AnyResource{MetadataViews.Resolver}

--- a/docs/tooling/nft-catalog/overview.mdx
+++ b/docs/tooling/nft-catalog/overview.mdx
@@ -78,7 +78,7 @@ import NFTCatalog from 0x49a7cda3a1eecc29
 	The NFTCatalogMetadata contains collection-level views corresponding to each
 	collection identifier.
 */
-pub fun main(): {String : NFTCatalog.NFTCatalogMetadata} {
+access(all) fun main(): {String : NFTCatalog.NFTCatalogMetadata} {
     return NFTCatalog.getCatalog()
 
 }
@@ -89,7 +89,7 @@ pub fun main(): {String : NFTCatalog.NFTCatalogMetadata} {
 ```swift
 import NFTCatalog from 0x49a7cda3a1eecc29
 
-pub fun main(): [String] {
+access(all) fun main(): [String] {
 		let catalog: {String : NFTCatalog.NFTCatalogMetadata} = NFTCatalog.getCatalog()
 		let catalogNames: [String] = []
 		for collectionIdentifier in catalog.keys {
@@ -106,7 +106,7 @@ import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
 
-pub fun main(ownerAddress: Address) : {String : Number} {
+access(all) fun main(ownerAddress: Address) : {String : Number} {
     let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
     let items : {String : Number} = {}
@@ -148,22 +148,22 @@ import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
 
-pub struct NFT {
-    pub let id : UInt64
-    pub let name : String
-    pub let description : String
-    pub let thumbnail : String
-    pub let externalURL : String
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
-    pub let privatePath: PrivatePath
-    pub let publicLinkedType: Type
-    pub let privateLinkedType: Type
-    pub let collectionName : String
-    pub let collectionDescription: String
-    pub let collectionSquareImage : String
-    pub let collectionBannerImage : String
-    pub let royalties: [MetadataViews.Royalty]
+access(all) struct NFT {
+    access(all) let id : UInt64
+    access(all) let name : String
+    access(all) let description : String
+    access(all) let thumbnail : String
+    access(all) let externalURL : String
+    access(all) let storagePath : StoragePath
+    access(all) let publicPath : PublicPath
+    access(all) let privatePath: PrivatePath
+    access(all) let publicLinkedType: Type
+    access(all) let privateLinkedType: Type
+    access(all) let collectionName : String
+    access(all) let collectionDescription: String
+    access(all) let collectionSquareImage : String
+    access(all) let collectionBannerImage : String
+    access(all) let royalties: [MetadataViews.Royalty]
 
     init(
             id: UInt64,
@@ -202,7 +202,7 @@ pub struct NFT {
     }
 }
 
-pub fun main(ownerAddress: Address) : { String : [NFT] } {
+access(all) fun main(ownerAddress: Address) : { String : [NFT] } {
     let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
     let items : [NFTRetrieval.BaseNFTViewsV1] = []
@@ -299,7 +299,7 @@ import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
 
-pub fun main(ownerAddress: Address) : {String : [UInt64]} {
+access(all) fun main(ownerAddress: Address) : {String : [UInt64]} {
     let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
 
@@ -337,22 +337,22 @@ import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
 
-pub struct NFT {
-    pub let id : UInt64
-    pub let name : String
-    pub let description : String
-    pub let thumbnail : String
-    pub let externalURL : String
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
-    pub let privatePath: PrivatePath
-    pub let publicLinkedType: Type
-    pub let privateLinkedType: Type
-    pub let collectionName : String
-    pub let collectionDescription: String
-    pub let collectionSquareImage : String
-    pub let collectionBannerImage : String
-    pub let royalties: [MetadataViews.Royalty]
+access(all) struct NFT {
+    access(all) let id : UInt64
+    access(all) let name : String
+    access(all) let description : String
+    access(all) let thumbnail : String
+    access(all) let externalURL : String
+    access(all) let storagePath : StoragePath
+    access(all) let publicPath : PublicPath
+    access(all) let privatePath: PrivatePath
+    access(all) let publicLinkedType: Type
+    access(all) let privateLinkedType: Type
+    access(all) let collectionName : String
+    access(all) let collectionDescription: String
+    access(all) let collectionSquareImage : String
+    access(all) let collectionBannerImage : String
+    access(all) let royalties: [MetadataViews.Royalty]
 
     init(
             id: UInt64,
@@ -389,7 +389,7 @@ pub struct NFT {
     }
 }
 
-pub fun main(ownerAddress: Address, collections: {String : [UInt64]}) : {String : [NFT] } {
+access(all) fun main(ownerAddress: Address, collections: {String : [UInt64]}) : {String : [NFT] } {
     let data : {String : [NFT] } = {}
 
     let catalog = NFTCatalog.getCatalog()
@@ -464,12 +464,12 @@ import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
 
-pub struct NFTCollectionData {
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
-    pub let privatePath: PrivatePath
-    pub let publicLinkedType: Type
-    pub let privateLinkedType: Type
+access(all) struct NFTCollectionData {
+    access(all) let storagePath : StoragePath
+    access(all) let publicPath : PublicPath
+    access(all) let privatePath: PrivatePath
+    access(all) let publicLinkedType: Type
+    access(all) let privateLinkedType: Type
 
     init(
             storagePath : StoragePath,
@@ -486,7 +486,7 @@ pub struct NFTCollectionData {
     }
 }
 
-pub fun main(ownerAddress: Address) : { String : {String : AnyStruct} }  {
+access(all) fun main(ownerAddress: Address) : { String : {String : AnyStruct} }  {
     let catalog = NFTCatalog.getCatalog()
     let account = getAuthAccount(ownerAddress)
     let items : [MetadataViews.NFTView] = []
@@ -539,16 +539,16 @@ import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
 
-pub struct NFTCollection {
-    pub let storagePath : StoragePath
-    pub let publicPath : PublicPath
-    pub let privatePath: PrivatePath
-    pub let publicLinkedType: Type
-    pub let privateLinkedType: Type
-    pub let collectionName : String
-    pub let collectionDescription: String
-    pub let collectionSquareImage : String
-    pub let collectionBannerImage : String
+access(all) struct NFTCollection {
+    access(all) let storagePath : StoragePath
+    access(all) let publicPath : PublicPath
+    access(all) let privatePath: PrivatePath
+    access(all) let publicLinkedType: Type
+    access(all) let privateLinkedType: Type
+    access(all) let collectionName : String
+    access(all) let collectionDescription: String
+    access(all) let collectionSquareImage : String
+    access(all) let collectionBannerImage : String
 
     init(
             storagePath : StoragePath,
@@ -573,7 +573,7 @@ pub struct NFTCollection {
     }
 }
 
-pub fun main(collectionIdentifier : String) : NFT? {
+access(all) fun main(collectionIdentifier : String) : NFT? {
         let catalog = NFTCatalog.getCatalog()
 
         assert(catalog.containsKey(collectionIdentifier), message: "Invalid Collection")

--- a/docs/tooling/unity-sdk/guides/convert.md
+++ b/docs/tooling/unity-sdk/guides/convert.md
@@ -110,9 +110,9 @@ public class TestStruct
 and the following Cadence struct:
 
 ```cadence
-pub struct TestStruct {
-    pub let i32: Int32
-    pub let s: String
+access(all) struct TestStruct {
+    access(all) let i32: Int32
+    access(all) let s: String
 }
 ```
 
@@ -166,18 +166,18 @@ public class Play
 If a Cadence struct contains another struct, the field should be annotated as a "Struct".  Given the following Cadence:
 
 ```cadence
-pub struct Other {
-    pub let i: Int16
+access(all) struct Other {
+    access(all) let i: Int16
 
-    pub init(i:Int16) {
+    access(all) init(i:Int16) {
         self.i=i
     }
 }
 
-pub struct Test {
-    pub let o : Other
+access(all) struct Test {
+    access(all) let o : Other
     
-    pub init(i: Int16) {
+    access(all) init(i: Int16) {
         self.o = Other(i:i)
     }
 }

--- a/docs/tooling/unity-sdk/samples/flow-words-tutorial.md
+++ b/docs/tooling/unity-sdk/samples/flow-words-tutorial.md
@@ -356,14 +356,14 @@ public class GuessResultPayload
 Let's compare these to the payloads for each event in the contract:
 
 ```cadence
-pub event CurrentState(currentState: [UserGuess])
-pub event LastGameStart(startTime: UFix64)
-pub event GuessResult(result: String)
+access(all) event CurrentState(currentState: [UserGuess])
+access(all) event LastGameStart(startTime: UFix64)
+access(all) event GuessResult(result: String)
 
-pub struct UserGuess
+access(all) struct UserGuess
 {
-    pub let Guess: String
-    pub let Result: String
+    access(all) let Guess: String
+    access(all) let Result: String
     init(guess: String, result: String)
     {
         self.Guess = guess
@@ -752,7 +752,7 @@ As this is a transaction, we once again check the three possible failure modes, 
 Next we parse our transaction’s emitted events.
 
 ```cadence
-pub event GuessResult(result: String)
+access(all) event GuessResult(result: String)
 ```
 
 We are expecting an event called GuessResult, with a single string parameter called result.  We created a C# version of that event: ```GuessResultPayload```.
@@ -936,11 +936,11 @@ Our global highscores are an array of Scores objects in the contract.
 
 ```cadence
 access(contract) let TopScores : [Scores]
-pub struct Scores
+access(all) struct Scores
 {
-    pub let AccId : Address
-    pub let Name : String
-    pub let Score : UInt
+    access(all) let AccId : Address
+    access(all) let Name : String
+    access(all) let Score : UInt
 }
 ```
 

--- a/docs/tooling/unity-sdk/samples/nft-browser.md
+++ b/docs/tooling/unity-sdk/samples/nft-browser.md
@@ -24,7 +24,7 @@ First we need to get a list of all collections on an account that are a subtype 
 ```cadence
 import NonFungibleToken from 0x1d7e57aa55817448
 
-pub fun main(addr: Address) : [StoragePath] {
+access(all) fun main(addr: Address) : [StoragePath] {
     //Get the AuthAccount for the given address.
     //The AuthAccount is needed because we're going to be looking into the Storage of the user
     var acct = getAuthAccount(addr)
@@ -60,7 +60,7 @@ list of IDs contained in that collection:
 ```cadence
 import NonFungibleToken from 0x1d7e57aa55817448
 
-pub fun main(addr: Address, path: StoragePath) : [UInt64] {
+access(all) fun main(addr: Address, path: StoragePath) : [UInt64] {
     //Get the AuthAccount for the given address.
     //The AuthAccount is needed because we're going to be looking into the Storage of the user
     var acct = getAuthAccount(addr)
@@ -81,7 +81,7 @@ After we get a list of the available NFT IDs, we need to get some basic data abo
 import NonFungibleToken from 0x1d7e57aa55817448
 import MetadataViews from 0x1d7e57aa55817448
 
-pub fun main(addr: Address, path: StoragePath, ids: [UInt64]) : {UInt64:AnyStruct?} {
+access(all) fun main(addr: Address, path: StoragePath, ids: [UInt64]) : {UInt64:AnyStruct?} {
     //Array to hold the NFT display data that we will return
     //We use AnyStruct? because that is the type that is returned by resolveView.
     var returnData: {UInt64:AnyStruct?} = {}
@@ -151,7 +151,7 @@ import NonFungibleToken from 0x1d7e57aa55817448
 import MetadataViews from 0x1d7e57aa55817448
 
 //Structure that will hold all the data we want for an NFT
-pub struct NFTData {
+access(all) struct NFTData {
     pub(set) var NFTView: AnyStruct?
     pub(set) var Display : AnyStruct?
     pub(set) var HTTPFile: AnyStruct?
@@ -191,7 +191,7 @@ pub struct NFTData {
     }
 }
 
-pub fun main(addr: Address, path: StoragePath, id: UInt64) : NFTData? {
+access(all) fun main(addr: Address, path: StoragePath, id: UInt64) : NFTData? {
     //Get account for address
     var acct = getAuthAccount(addr)
     
@@ -275,8 +275,8 @@ public class File
 Compare this to the File interface in the MetadataViews contract:
 
 ```cadence
-    pub struct interface File {
-        pub fun uri(): String
+    access(all) struct interface File {
+        access(all) fun uri(): String
     }
 ```
 
@@ -284,13 +284,13 @@ The MetadataViews.File interface doesn't actually contain any fields, only a sin
 File interface (HTTPFile and IPFSFile), we chose to combine the possible fields into our File class.
 
 ```cadence
-pub struct HTTPFile: File {
-        pub let url: String
+access(all) struct HTTPFile: File {
+        access(all) let url: String
 }
 
-pub struct IPFSFile: File {
-    pub let cid: String
-    pub let path: String?
+access(all) struct IPFSFile: File {
+    access(all) let cid: String
+    access(all) let path: String?
 }
 ```
 

--- a/docs/tooling/unity-sdk/samples/nft-example.md
+++ b/docs/tooling/unity-sdk/samples/nft-example.md
@@ -381,7 +381,7 @@ It executes the script defined in GetNFTsOnAccount.cdc:
 ```cadence
 import SDKExampleNFT from 0xf8d6e0586b0a20c7
 
-pub fun main(addr:Address): {UInt64:{String:String}} {
+access(all) fun main(addr:Address): {UInt64:{String:String}} {
 
     //Get a capability to the SDKExampleNFT collection if it exists.  Return an empty dictionary if it does not
     let collectionCap = getAccount(addr).getCapability<&{SDKExampleNFT.CollectionPublic}>(SDKExampleNFT.CollectionPublicPath)

--- a/docs/tooling/unity-sdk/samples/quickstart.md
+++ b/docs/tooling/unity-sdk/samples/quickstart.md
@@ -65,7 +65,7 @@ More information is available at [Developer Portal](../../../cadence/language/in
 First we'll define the script that we want to run:
 
 ```csharp
-const string code = @"pub fun main(message: String): Int{
+const string code = @"access(all) fun main(message: String): Int{
     log(message)
     return 42
 }";
@@ -237,16 +237,16 @@ First we need to define the contract we wish to deploy.
 
 ```csharp
 const string contractCode = @"
-    pub contract HelloWorld {
-        pub let greeting: String
+    access(all) contract HelloWorld {
+        access(all) let greeting: String
 
-        pub event TestEvent(field: String)
+        access(all) event TestEvent(field: String)
 
         init() {
             self.greeting = ""Hello, World!""
         }
 
-        pub fun hello(data: String): String {
+        access(all) fun hello(data: String): String {
             emit TestEvent(field:data)
             return self.greeting
         }

--- a/docs/tutorials/flow-app-quickstart.mdx
+++ b/docs/tutorials/flow-app-quickstart.mdx
@@ -271,7 +271,7 @@ export default function Home() {
       cadence: `
         import Profile from 0xProfile
 
-        pub fun main(address: Address): Profile.ReadOnly? {
+        access(all) fun main(address: Address): Profile.ReadOnly? {
           return Profile.read(address)
         }
       `,
@@ -328,7 +328,7 @@ await fcl.query({
   cadence: `
     import Profile from 0xProfile
 
-    pub fun main(address: Address): Profile.ReadOnly? {
+    access(all) fun main(address: Address): Profile.ReadOnly? {
       return Profile.read(address)
     }
   `,
@@ -410,7 +410,7 @@ export default function Home() {
       cadence: `
         import Profile from 0xProfile
 
-        pub fun main(address: Address): Profile.ReadOnly? {
+        access(all) fun main(address: Address): Profile.ReadOnly? {
           return Profile.read(address)
         }
       `,
@@ -548,7 +548,7 @@ export default function Home() {
       cadence: `
         import Profile from 0xProfile
 
-        pub fun main(address: Address): Profile.ReadOnly? {
+        access(all) fun main(address: Address): Profile.ReadOnly? {
           return Profile.read(address)
         }
       `,

--- a/docs/tutorials/kitty-items/modify.md
+++ b/docs/tutorials/kitty-items/modify.md
@@ -115,13 +115,13 @@ Open the `/cadence/contracts/KittyItems.cdc` file and make the following changes
 Locate the `enum Kind` object and add a new case (`shades`) to the bottom of the list:
 
 ```cadence /cadence/contracts/KittyItems.cdc
-pub enum Kind: UInt8 {
-    pub case fishbowl
-    pub case fishhat
-    pub case milkshake
-    pub case tuktuk
-    pub case skateboard
-    pub case shades
+access(all) enum Kind: UInt8 {
+    access(all) case fishbowl
+    access(all) case fishhat
+    access(all) case milkshake
+    access(all) case tuktuk
+    access(all) case skateboard
+    access(all) case shades
 }
 ```
 
@@ -130,7 +130,7 @@ pub enum Kind: UInt8 {
 This method is used to set the name and description of a specified NFT. Locate the the `kindToString` method and add a new case (`Kind.shades`) to the bottom of the switch statement:
 
 ```cadence /cadence/contracts/KittyItems.cdc
-pub fun kindToString(_ kind: Kind): String {
+access(all) fun kindToString(_ kind: Kind): String {
     switch kind {
         case Kind.fishbowl:
             return "Fishbowl"

--- a/docs/tutorials/testnet-deployment.md
+++ b/docs/tutorials/testnet-deployment.md
@@ -140,7 +140,7 @@ You can then specify your contracts you wish to deploy in the configuration like
 Here's a sketch of the contract source files:
 
 ```
-pub contract NonFungibleToken {
+access(all) contract NonFungibleToken {
   // ...
 }
 ```
@@ -148,7 +148,7 @@ pub contract NonFungibleToken {
 ```
 import NonFungibleToken from "./NonFungibleToken.cdc"
 
-pub contract KittyItems {
+access(all) contract KittyItems {
   // ...
 }
 ```


### PR DESCRIPTION
With https://github.com/onflow/cadence/pull/2540 merged, these access modifiers are going away in Stable Cadence.

Note that `docs/concepts/staking/05-epoch-scripts-events.md` and `docs/tooling/unity-sdk/samples/nft-browser.md` still contain `pub(set)` access modifiers, but given that these reflect real contracts, I did not want to update them unilaterally. Once these contracts are updated, the docs should change to match them. 