### PR TITLE
fix tools categories formatting

### DIFF
--- a/docs/tooling/fcl-dev-wallet/_category_.json
+++ b/docs/tooling/fcl-dev-wallet/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "FCL Dev Wallet",
+}

--- a/docs/tooling/flow-cadut/_category_.json
+++ b/docs/tooling/flow-cadut/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Flow Cadut",
+}

--- a/docs/tooling/nft-catalog/_category_.json
+++ b/docs/tooling/nft-catalog/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "NFT Catalog",
+}


### PR DESCRIPTION
#154 
https://docs-git-nialexsan-154-fixed-tools-title-formatting-onflow.vercel.app/tooling/intro
tools titles should have consistent formatting
![Screenshot 2023-07-05 at 17 37 46](https://github.com/onflow/docs/assets/12097569/3ec6be3d-f632-46f2-b403-b8e25e061e28)
