### PR TITLE
update hybrid-custody testnet deployment alert

### DIFF
--- a/docs/concepts/hybrid-custody/get-started.mdx
+++ b/docs/concepts/hybrid-custody/get-started.mdx
@@ -15,8 +15,9 @@ perspective of a wallet or NFT marketplace.
 <Callout type="warning">
 
 Note that the documentation on Hybrid Custody covers the current state and will likely differ from the final
-implementation. Builders should be aware that breaking changes may follow before reaching a final community consensus
-on implementation. Interested in shaping the conversation? [Join in!](https://github.com/onflow/flips/pull/72).
+implementation. **Testnet is currently out of sync with docs and will be updated shortly.** Builders should be aware
+that breaking changes may follow before reaching a final community consensus on implementation. Interested in
+contributing? [Check out the source!](https://github.com/onflow/hybrid-custody).
 
 </Callout>
 

--- a/docs/concepts/hybrid-custody/guides/account-model.mdx
+++ b/docs/concepts/hybrid-custody/guides/account-model.mdx
@@ -28,8 +28,9 @@ owned assets.
 <Callout type="warning">
 
 Note that the documentation on Hybrid Custody covers the current state and will likely differ from the final
-implementation. Builders should be aware that breaking changes may follow before reaching a final community consensus
-on implementation. Interested in shaping the conversation? [Join in!](https://github.com/onflow/flips/pull/72).
+implementation. **Testnet is currently out of sync with docs and will be updated shortly.** Builders should be aware
+that breaking changes may follow before reaching a final community consensus on implementation. Interested in
+contributing? [Check out the source!](https://github.com/onflow/hybrid-custody).
 
 </Callout>
 

--- a/docs/concepts/hybrid-custody/guides/linking-accounts.mdx
+++ b/docs/concepts/hybrid-custody/guides/linking-accounts.mdx
@@ -19,8 +19,9 @@ of the dApp account as Account Linking.
 <Callout type="warning">
 
 Note that the documentation on Hybrid Custody covers the current state and will likely differ from the final
-implementation. Builders should be aware that breaking changes may follow before reaching a final community consensus
-on implementation. Interested in shaping the conversation? [Join in!](https://github.com/onflow/flips/pull/72).
+implementation. **Testnet is currently out of sync with docs and will be updated shortly.** Builders should be aware
+that breaking changes may follow before reaching a final community consensus on implementation. Interested in
+contributing? [Check out the source!](https://github.com/onflow/hybrid-custody).
 
 </Callout>
 

--- a/docs/concepts/hybrid-custody/guides/walletless-onboarding.mdx
+++ b/docs/concepts/hybrid-custody/guides/walletless-onboarding.mdx
@@ -12,8 +12,9 @@ and self-sovereignty at a user’s own pace.
 <Callout type="warning">
 
 Note that the documentation on Hybrid Custody covers the current state and will likely differ from the final
-implementation. Builders should be aware that breaking changes may follow before reaching a final community consensus
-on implementation. Interested in shaping the conversation? [Join in!](https://github.com/onflow/flips/pull/72).
+implementation. **Testnet is currently out of sync with docs and will be updated shortly.** Builders should be aware
+that breaking changes may follow before reaching a final community consensus on implementation. Interested in
+contributing? [Check out the source!](https://github.com/onflow/hybrid-custody).
 
 </Callout>
 

--- a/docs/concepts/hybrid-custody/index.mdx
+++ b/docs/concepts/hybrid-custody/index.mdx
@@ -19,8 +19,9 @@ The full Hybrid Custody experience is enabled by three core components:
 <Callout type="warning">
 
 Note that the documentation on Hybrid Custody covers the current state and will likely differ from the final
-implementation. Builders should be aware that breaking changes may follow before reaching a final community consensus
-on implementation. Interested in shaping the conversation? [Join in!](https://github.com/onflow/flips/pull/72).
+implementation. **Testnet is currently out of sync with docs and will be updated shortly.** Builders should be aware
+that breaking changes may follow before reaching a final community consensus on implementation. Interested in
+contributing? [Check out the source!](https://github.com/onflow/hybrid-custody).
 
 </Callout>
 


### PR DESCRIPTION
Adding note in alert that testnet contracts are currently out of sync with documentation as recommended by a community member.