### PR TITLE
Adding QuickNode to Dapp Architecture Tutorial

### DIFF
--- a/docs/tutorials/DappArchitectures.mdx
+++ b/docs/tutorials/DappArchitectures.mdx
@@ -28,6 +28,7 @@ But sometimes, dapps need to submit transactions to the blockchain from their ba
 Several SDKs are available to interact with the Flow blockchain, including some that are community-run. The SDKs interact with the access nodes of the Flow blockchain.
 We recommend maintaining a queuing infrastructure within the dapp’s backend to handle the scalability surge.
 There are some third-party services available that make managing transactions from the dapp backend easier :
+- [QuickNode](https://www.quicknode.com/chains/flow): QuickNode provides a reliable node service to access Flow blockchain. QuickNode's service is designed to optimize developer productivity by eliminating the complexities of setting up and maintaining their own nodes. By leveraging QuickNode's infrastructure, developers can focus on building and deploying decentralized applications (dApps) without the hassle of managing the underlying blockchain infrastructure.
 - [Alchemy](https://www.alchemy.com/flow): To get a dedicated Flow blockchain access node, Alchemy provides a managed access node service for the Flow dapp developers.
 Alchemy can allow dapp devs to bypass the rate limits imposed by official Flow access nodes without the operational overhead of running an access node.
 - [Tatum](https://apidoc.tatum.io/): Tatum provides REST APIs to let dapps perform high-level blockchain operations like creating Flow accounts, sending NFTs, or FLOW tokens to an address.


### PR DESCRIPTION
This PR is for mentioning QuickNode as a node provider in the tutorial since QuickNode supports Flow blockchain.