### PR TITLE
node operator guide changes

### DIFF
--- a/docs/building-on-flow/nodes/index.md
+++ b/docs/building-on-flow/nodes/index.md
@@ -3,6 +3,8 @@ title: Flow Nodes
 sidebar_position: 7
 ---
 
+# Hello Node Operator!
+
 Flow nodes are vital components of the Flow blockchain. These nodes are responsible for a variety of network operations to maintain the distributed ledger.
 
 ## Why run a node?
@@ -16,27 +18,56 @@ Flow multirole architecture makes it more scalable and provides several node typ
 
 ## Which node should you run?
 
-The different types of nodes are described [here](./node-operation/node-roles.mdx). As node operator, you can choose to run any of the different types of node that best fits your needs.
+The different types of nodes are described [here](./node-roles.mdx). As node operator, you can choose to run any of the different types of node that best fits your needs.
 
-### Observer node
-The observer node is one of the easiest node to spin up and can be run by Dapp developers who need the latest block data available locally e.g. a wallet application that needs to track the latest block ID and height.
+The nodes are classified as follows
+
+![Flownodesdiagram.jpg](Flownodesdiagram.jpg)
+
+## Light node a.k.a. Observer node
+
+The light node is one of the easiest nodes to spin up and can be run by Dapp developers who need the latest block data available locally, e.g. a wallet application that needs to track the latest block ID and height.
 In addition to supporting dapps, an observer node can also be run by access node operators who want to scale their access nodes' endpoints. Access node operators can spin up geographically dispersed observer nodes which can talk to their staked access nodes and to each other.
 
 The observer node is not staked but still provides the same API as the access node.
 
-To run an observer node, follow this [guide](./node-operation/observer-node.mdx).
+To run a light node, follow this [guide](./observer-node.mdx).
 
-### Access node
+## Archive node
+
+The Archive node provides a scalable and efficient way to access the history of Flow protocol and the execution state for the current spork. Like the observer node, it too can be run by anyone without being staked or added to the approved list of nodes.
+The Archive node follows the chain, stores and indexes both protocol and execution state, and allows retrieval of blocks, collections, transactions and events from the genesis of the current spork.
+
+It also allows script execution and other read-only queries that require the execution state to be read. It can answer any queries from past data e.g. “what was the Flow account balance at height X?”, where X is several thousand blocks in the past.
+
+The archive node is currently in beta and will be available as a GA release in H2 2023 (see [here](https://flow.com/post/flow-blockchain-node-operation-archive-node) for more)
+
+## Full node
+
+In a nutshell, Full Nodes are staked network participants that drive network progress, e.g. by creating and executing new blocks. They are the primary contributors to network safety (all of them validate the correctness of the consensus process and secure the network additionally through their role-specific tasks). In comparison, Light Nodes don't contribute to the networks progress. Though, they help to secure the network by also validating the integrity of the consensus process.
+- The Access node is a full node that serves as an RPC node and acts as a gateway node for the network.
+- The Validator node (Collection, Consensus, Verification and Execution) is a full node that plays a role in block generation.
+
+
+## Access node
 If you want local access to the protocol state data (blocks, collections, transactions) and do not want to use one of the community access nodes you can run an access node.
 Dapp developers, chain explorers, chain analytics etc. who want exclusive access to chain data and not be subject to the rate-limits on the community access node can choose to run an access node.
 
-An access node is staked but since it does not participate in the core Flow protocol, it does not receive any staking rewards.
+An access node is minimally staked for network security.
+The central goal for Access Nodes is to provide RPC functionality to its node operator.
+In comparison, contributing to protocol progress (e.g. routing transactions to collector clusters, relaying blocks to the unstaked peer-to-peer network, etc.) should only take up a marginal fraction an Access Node's computational resources.
+Furthermore, Access Node operators can freely rate-limit the amount of resources their Access Node dedicates to supporting the broader ecosystem. Therefore, Access Nodes do not receive staking rewards.
 To run an access node, see the [Running a staked node](#running-a-staked-node) section below.
 
-Alternately, instead of running your access node, you can use the [Flow community](./access-api.mdx) access nodes or the ones run by any of the other node operators.
+Alternately, instead of running an access node, you can use the [Flow community](../access-api.mdx) access nodes or the ones run by any of the other node operators.
 
-### Collection, Consensus, Verification and Execution node
-If you want your node to participate in the nitty-gritty of Flow protocol and help in block or collection creation, transaction execution, result verification or block verification then you should run one of these four node roles.
+## Validator node
+
+You can also be a core participant in running the Flow network and contribute to securing it. Depending on your preference, you could run one or any combination of the following node roles:
+- Collection Nodes collaboratively create batches of transactions (in Flow terminology collections).
+- Consensus Nodes create blocks, schedule them for asynchronous execution, and commit execution results once they are verified (so called sealing). In addition, they orchestrate the Flow protocol and enforce protocol compliance.
+- Execution Nodes asynchronously execute blocks. They are the power-houses in the protocol, providing the vast computational resources available to Flow transactions.
+- Verification Nodes check the execution results in a distributed manner.
 
 Nodes with these roles are staked and also receive staking rewards.
 
@@ -50,8 +81,8 @@ Before proceeding, ensure you have the stake required for your new node and that
 
 To set up a new Flow node you will need to complete the following steps:
 
-1. [Provision](./node-operation/node-setup.mdx) the machine on which your node will run.
+1. [Provision](./node-setup.mdx) the machine on which your node will run.
 
-2. [Generate and register](./node-operation/node-bootstrap.mdx) your node identity.
+2. [Generate and register](./node-bootstrap.mdx) your node identity.
 
-3. [Start](./node-operation/node-bootstrap.mdx#step-3---start-your-flow-node) your node!
+3. [Start](./node-bootstrap.mdx#step-3---start-your-flow-node) your node!

--- a/docs/building-on-flow/nodes/index.md
+++ b/docs/building-on-flow/nodes/index.md
@@ -18,11 +18,11 @@ Flow multirole architecture makes it more scalable and provides several node typ
 
 ## Which node should you run?
 
-The different types of nodes are described [here](./node-roles.mdx). As node operator, you can choose to run any of the different types of node that best fits your needs.
+The different types of nodes are described [here](./node-operation/node-roles.mdx). As node operator, you can choose to run any of the different types of node that best fits your needs.
 
 The nodes are classified as follows
 
-![Flownodesdiagram.jpg](Flownodesdiagram.jpg)
+![Flownodesdiagram.jpg](./node-operation/Flownodesdiagram.jpg)
 
 ## Light node a.k.a. Observer node
 
@@ -31,7 +31,7 @@ In addition to supporting dapps, an observer node can also be run by access node
 
 The observer node is not staked but still provides the same API as the access node.
 
-To run a light node, follow this [guide](./observer-node.mdx).
+To run a light node, follow this [guide](./node-operation/observer-node.mdx).
 
 ## Archive node
 
@@ -59,7 +59,7 @@ In comparison, contributing to protocol progress (e.g. routing transactions to c
 Furthermore, Access Node operators can freely rate-limit the amount of resources their Access Node dedicates to supporting the broader ecosystem. Therefore, Access Nodes do not receive staking rewards.
 To run an access node, see the [Running a staked node](#running-a-staked-node) section below.
 
-Alternately, instead of running an access node, you can use the [Flow community](../access-api.mdx) access nodes or the ones run by any of the other node operators.
+Alternately, instead of running an access node, you can use the [Flow community](./access-api.mdx) access nodes or the ones run by any of the other node operators.
 
 ## Validator node
 
@@ -81,8 +81,8 @@ Before proceeding, ensure you have the stake required for your new node and that
 
 To set up a new Flow node you will need to complete the following steps:
 
-1. [Provision](./node-setup.mdx) the machine on which your node will run.
+1. [Provision](./node-operation/node-setup.mdx) the machine on which your node will run.
 
-2. [Generate and register](./node-bootstrap.mdx) your node identity.
+2. [Generate and register](./node-operation/node-bootstrap.mdx) your node identity.
 
-3. [Start](./node-bootstrap.mdx#step-3---start-your-flow-node) your node!
+3. [Start](./node-operation/node-bootstrap.mdx#step-3---start-your-flow-node) your node!

--- a/versioned_docs/version-stable/concepts/nodes/node-operation/access-node-setup.md
+++ b/versioned_docs/version-stable/concepts/nodes/node-operation/access-node-setup.md
@@ -76,8 +76,8 @@ tar -xvf boot-tools.tar
 ```
 
 ```shell CheckSHA256
-sha256sum ./boot-tools/bootstrap
-9673e2c29c7f350caea8ff20dbc1e2ab24853416c2d2078c1a21790773315972  ./boot-tools/bootstrap
+sha256sum ./boot-tools/bootstrapcmd
+9673e2c29c7f350caea8ff20dbc1e2ab24853416c2d2078c1a21790773315972  ./boot-tools/bootstrapcmd
 ```
 
 > If you have downloaded the bootstrapping kit previously, ensure the SHA256 hash for it still matches. If not, re-download to ensure you are using the most up-to-date version.
@@ -89,11 +89,11 @@ sha256sum ./boot-tools/bootstrap
 # Generate Keys
 $ mkdir ./bootstrap
 # YOUR_NODE_ADDRESS: FQDN associated to your instance
-$ ./boot-tools/bootstrap key --address "<YOUR_NODE_ADDRESS_GOES_HERE>:3569" --role access -o ./bootstrap
+$ ./boot-tools/bootstrapcmd key --address "<YOUR_NODE_ADDRESS_GOES_HERE>:3569" --role access -o ./bootstrap
 ```
 
 ```shell Example
-$./boot-tools/bootstrap key --address "flowaccess.mycompany.com:3569" --role access  -o ./bootstrap
+$./boot-tools/bootstrapcmd key --address "flowaccess.mycompany.com:3569" --role access  -o ./bootstrap
 <nil> DBG will generate networking key
 <nil> INF generated networking key
 <nil> DBG will generate staking key

--- a/versioned_docs/version-stable/concepts/nodes/node-operation/observer-node.mdx
+++ b/versioned_docs/version-stable/concepts/nodes/node-operation/observer-node.mdx
@@ -59,7 +59,7 @@ Download the Bootstrapping kit, and generate the observer networking key.
 ```shell
 curl -sL -O storage.googleapis.com/flow-genesis-bootstrap/boot-tools.tar
 tar -xvf boot-tools.tar
-./boot-tools/bootstrap observer-network-key  --output-file  ./flow_observer/bootstrap/network.key
+./boot-tools/bootstrapcmd observer-network-key  --output-file  ./flow_observer/bootstrap/network.key
 ```
 
 _If you are running on a mac, download the boot-tools for mac to generate the key_


### PR DESCRIPTION
This [PR](https://github.com/onflow/docs/pull/231) that I merged today updated the node operator guide. However, the node operator guide exists in two places:
1. In the [index.md](https://github.com/onflow/docs/blob/dd112e9bf1ccb9420014882879503f7b23b35bad/docs/building-on-flow/nodes/index.md) under docs/building-on-flow/nodes

And,

2. In the [index.md](https://github.com/onflow/docs/blob/6a00297082091128376a908bd78ce88129789b7d/docs/building-on-flow/nodes/node-operation/index.md) under docs/building-on-flow/nodes/node-operation/index.md which the [PR](https://github.com/onflow/docs/pull/231) updated.

This PR updates the file under `building-on-flow/nodes` with the same contents but updated relative links.

**Why is the file repeated?**
TBH, I am not 100% sure. When we were moving the old site to this new repo, this was a hack to achieve what we wanted - the same guide show up under `Flow Nodes` and under`Node Operators` which is under `Flow Nodes`. 
<img width="1182" alt="Screen Shot 2023-09-04 at 10 12 24 AM" src="https://github.com/onflow/docs/assets/1117327/2d7393a4-80e7-44eb-b8c1-60cdb0afcc04">

Other changes in the PR:
1. The `bootstrap` command has been renamed and is now called `bootstrapcmd`.