### PR TITLE
updating the light node (observer node) documentation 

### DIFF
--- a/docs/references/run-and-secure/node-operation/observer-node.mdx
+++ b/docs/references/run-and-secure/node-operation/observer-node.mdx
@@ -137,7 +137,7 @@ docker run --rm \
  -v $PWD/flow_observer/bootstrap:/bootstrap:ro  \
  -v $PWD/flow_observer/data:/data:rw \
  --name flow_observer \
- -p 8071:8071 \
+ -p 80:80 \
  -p 3569:3569 \
  -p 9000:9000 \
  -p 9001:9001 \
@@ -145,11 +145,12 @@ docker run --rm \
  --bootstrapdir=/bootstrap \
  --datadir=/data/protocol \
  --bind 0.0.0.0:3569  \
+ --rest-addr=:80 \
  --loglevel=error \
  --secretsdir=/data/secrets  \
- --upstream-node-addresses=access-008.mainnet20.nodes.onflow.org:9001 \
+ --upstream-node-addresses=access-008.mainnet23.nodes.onflow.org:9001 \
  --upstream-node-public-keys=11742552d21ac93da37ccda09661792977e2ca548a3b26d05f22a51ae1d99b9b75c8a9b3b40b38206b38951e98e4d145f0010f8942fd82ddf0fb1d670202264a \
- --bootstrap-node-addresses=access-008.mainnet20.nodes.onflow.org:3570  \
+ --bootstrap-node-addresses=access-008.mainnet23.nodes.onflow.org:3570  \
  --bootstrap-node-public-keys=11742552d21ac93da37ccda09661792977e2ca548a3b26d05f22a51ae1d99b9b75c8a9b3b40b38206b38951e98e4d145f0010f8942fd82ddf0fb1d670202264a \
  --observer-networking-key-path=/bootstrap/network.key
 ```
@@ -161,7 +162,7 @@ docker run --rm \
  -v $PWD/flow_observer/bootstrap:/bootstrap:ro  \
  -v $PWD/flow_observer/data:/data:rw \
  --name flow_observer \
- -p 8071:8071 \
+ -p 80:80 \
  -p 3569:3569 \
  -p 9000:9000 \
  -p 9001:9001 \
@@ -169,11 +170,12 @@ docker run --rm \
  --bootstrapdir=/bootstrap \
  --datadir=/data/protocol \
  --bind 0.0.0.0:3569  \
+ --rest-addr=:80 \
  --loglevel=error \
  --secretsdir=/data/secrets  \
- --upstream-node-addresses=access-003.devnet37.nodes.onflow.org:9001 \
+ --upstream-node-addresses=access-003.devnet47.nodes.onflow.org:9001 \
  --upstream-node-public-keys=b662102f4184fc1caeb2933cf87bba75cdd37758926584c0ce8a90549bb12ee0f9115111bbbb6acc2b889461208533369a91e8321eaf6bcb871a788ddd6bfbf7 \
- --bootstrap-node-addresses=access-003.devnet37.nodes.onflow.org:3570  \
+ --bootstrap-node-addresses=access-003.devnet47.nodes.onflow.org:3570  \
  --bootstrap-node-public-keys=b662102f4184fc1caeb2933cf87bba75cdd37758926584c0ce8a90549bb12ee0f9115111bbbb6acc2b889461208533369a91e8321eaf6bcb871a788ddd6bfbf7 \
  --observer-networking-key-path=/bootstrap/network.key
 ```
@@ -199,7 +201,10 @@ e.g. querying the gRPC API endpoint using Flow CLI
 flow blocks get latest --host localhost:9000
 ```
 
-> REST API is currently not support (see [issue](https://github.com/onflow/flow-go/issues/3138))
+e.g. querying the REST API endpoint using curl
+```shell
+curl "http://localhost/v1/blocks?height=sealed"
+```
 
 The light node, like the other type of Flow nodes, also produces Prometheus metrics that can be used to monitor node health. More on that [here](./node-setup.mdx#monitoring-and-metrics)
 


### PR DESCRIPTION
REST is now supported on the observer node (see [issue](https://github.com/onflow/flow-go/pull/4499))
This PR updates the documentation.