### PR TITLE
Add Solidity to Cadence BAYC tutorial

### DIFF
--- a/versioned_docs/version-stable/cadence/solidity-to-cadence.md
+++ b/versioned_docs/version-stable/cadence/solidity-to-cadence.md
@@ -494,3 +494,7 @@ can be called as
 `self.foo(balance: 30.0)`
 or as
 `self.foo(30.0)`
+
+## Additional resources
+* Cadence or Solidity: [On-Chain Token Transfer Deep Dive](https://flow.com/engineering-blogs/flow-blockchain-programming-language-smart-contract-cadence-solidity-comparison-ethereum)
+* Implementing the [Bored Ape Yacht Club](https://flow.com/post/implementing-the-bored-ape-yacht-club-smart-contract-in-cadence) smart contract in Cadence


### PR DESCRIPTION
Was added in https://github.com/onflow/docs/pull/273/files, but only to `/next`.   This PR makes sure that the file is in sync in the current docs.