### PR TITLE
Fix Cadence Page

### DIFF
--- a/docs/build/cadence.md
+++ b/docs/build/cadence.md
@@ -189,19 +189,19 @@ but using an interpreter for the first version allows us to refine the language 
 Now that you've learned about the goals and design of Cadence and Flow, you're ready to get started with the Flow emulator and tools!
 Go to the [Getting Started](../cadence/tutorial/01-first-steps.md) page to work through language fundamentals and tutorials.
 
-# why.md
+## Why Cadence?
 
-## 1. Security and Safety
+### 1. Security and Safety
 
 Cadence provides security and safety guarantees that greatly simplify the development of secure smart contracts. As smart contracts often deal with valuable assets, Cadence provides the resource-oriented programming paradigm, which guarantees that assets can only exist in one location at a time, cannot be copied, and cannot be accidentally lost or deleted.
 Cadence includes several language features which prevent entire classes of bugs.
 These security and safety features allow smart contract developers to focus on the business logic of their contract instead of preventing accidents and attacks.
 
-## 2. Composability
+### 2. Composability
 
 Cadence enables composability. Resources (which are arbitrary user-defined data types) are stored directly in users’ accounts, and can flow freely between contracts: They can be passed as arguments to functions, returned from functions, or even combined in arbitrary data structures. This makes implementing business logic easier, more natural and promotes reuse of existing logic.
 
-## 3. Simplicity
+### 3. Simplicity
 
 Cadence’s syntax is inspired by popular modern general-purpose programming languages like [Swift](https://developer.apple.com/swift/), [Kotlin](https://kotlinlang.org/), and [Rust](https://www.rust-lang.org/), so developers will find the syntax and the semantics familiar.
 Practical tooling, documentation, and examples enable developers to start creating programs quickly and effectively. Hundreds of developers were able to learn Cadence quickly and develop production-quality smart contracts with it shortly.


### PR DESCRIPTION
Gets rid of `why.md` on the Cadence page.  May need to resthink structure in the future but this provides a good short term fix.