### PR TITLE
Update path identifier documentation

### DIFF
--- a/docs/cadence/language/accounts/paths.mdx
+++ b/docs/cadence/language/accounts/paths.mdx
@@ -7,7 +7,7 @@ Account storage stores objects under paths.
 Paths consist of a domain and an identifier.
 
 Paths start with the character `/`, followed by the domain, the path separator `/`,
-and finally the identifier.
+and finally the identifier. The identifier must start with a letter and can only be followed by letters, numbers, or the underscore `_`. 
 For example, the path `/storage/test` has the domain `storage` and the identifier `test`.
 
 There are two valid domains: `storage` and `public`.


### PR DESCRIPTION
It took me a long time to realize I can't use the sign `-` in my identifier path as the `StoragePath` function swallows the error. So wanted to add some docs for this.