### PR TITLE
Fix Flowser icon link

### DIFF
--- a/docs/community-resources/projects.mdx
+++ b/docs/community-resources/projects.mdx
@@ -165,11 +165,11 @@ Explore an array of exciting, grassroots initiatives, and projects that thrive w
     href: 'https://flowser.dev/',
     description: 'Flowser combines all the tools for local development and gives you a clear UI to inspect the local Flow network.',
     customProps: {
-      icon: 'https://raw.githubusercontent.com/onflowser/flowser/main/frontend/public/logo.svg',
+      icon: 'https://flowser.dev/icon.png',
       author: {
         name: 'Flowser',
         profileImage:
-          'https://raw.githubusercontent.com/onflowser/flowser/main/frontend/public/logo.svg',
+          'https://flowser.dev/icon.png',
       },
       numStars: 0,
       twitterLink: 'https://twitter.com/onflowser',

--- a/docs/tools/index.mdx
+++ b/docs/tools/index.mdx
@@ -16,11 +16,11 @@ import { useLocation } from '@docusaurus/router';
     href: 'https://flowser.dev/',
     description: 'Flowser combines all the tools for local development and gives you a clear UI to inspect the local Flow network.',
     customProps: {
-      icon: 'https://raw.githubusercontent.com/onflowser/flowser/main/frontend/public/logo.svg',
+      icon: 'https://flowser.dev/icon.png',
       author: {
         name: 'Flowser',
         profileImage:
-          'https://raw.githubusercontent.com/onflowser/flowser/main/frontend/public/logo.svg',
+          'https://flowser.dev/icon.png',
       },
       twitterLink: 'https://twitter.com/onflowser',
       githubLink: 'https://github.com/onflowser/flowser'


### PR DESCRIPTION
We recently changed the structure of our project files, so the old link no longer works. Instead, I used a stable link on flowser.dev domain.