### PR TITLE
Update access-node-setup.md

### DIFF
--- a/docs/networks/node-ops/nodes/node-operation/FAQ.md
+++ b/docs/networks/node-ops/nodes/node-operation/FAQ.md
@@ -7,11 +7,11 @@ sidebar_position: 1
 
 ### Can anybody run a node? What is the approval process?
 
-Anyone can run an [observer node](./observer-node.md).
+Anyone can run an [Observer Node](./observer-node.md) without needing to stake FLOW.
 
-Very soon, Access nodes too will be permissionless and anyone will be able to run one.
+Anyone can run an Access Node after registering and staking. See [Access Node Setup](./access-node-setup.md) for detailed instructions.
 
-For the other node types, individuals can go through an application process that involves asking about their background and experience contributing to decentralized projects. To pursue an application, please visit [the Flow website here to apply](https://www.onflow.org/node-validators).
+For the other node roles, individuals can go through an application process that involves asking about their background and experience contributing to decentralized projects. To pursue an application, please visit [the Flow website here to apply](https://www.onflow.org/node-validators).
 
 Pending approval, new node operators will be onboarded and invited to join a webinar to meet the team and share more about how they’ll grow the community. Node Operators are invited to join and participate in Flow's Node Validator Discord channel for setup questions and network announcements.
 

--- a/docs/networks/node-ops/nodes/node-operation/access-node-setup.md
+++ b/docs/networks/node-ops/nodes/node-operation/access-node-setup.md
@@ -259,7 +259,7 @@ First you'll need to provision a machine or virtual machine to run your node sof
 
 The access node can be run as a docker container with the following command by replacing `nodeid` with your node ID and adjusting the other parameters as per your setup. 
 
-Be sure to use the version tag corresponding to the current network version (see [here](https://github.com/onflow/flow-go/releases) for version releases).
+Be sure to set `$VERSION` below to the version tag (eg. `v1.2.3`) corresponding to the current network version (see [here](https://github.com/onflow/flow-go/releases) for version releases). Set `$NODEID` to your node's ID (see [Generate Your Node Identity](#generate-your-node-identity) section above).
 
 ```shell
 docker run --rm \
@@ -267,8 +267,8 @@ docker run --rm \
   -v $PWD/data:/data:rw \
   --name flow-go \
   --network host \
-  gcr.io/flow-container-registry/access:$VERSION \ # Use the version for the current spork, from https://github.com/onflow/flow-go/releases
-  --nodeid=[Insert you NODE ID here] \
+  gcr.io/flow-container-registry/access:$VERSION \
+  --nodeid=$NODEID \
   --bootstrapdir=/bootstrap \
   --datadir=/data/protocol \
   --secretsdir=/data/secrets  \
@@ -283,14 +283,14 @@ docker run --rm \
   --loglevel=error
 ```
 
-Example, for the Node ID `e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5`, the docker command be the following,
+For example, if your Node ID is `e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5` and the software version is `v1.2.3`, the Docker command would be the following:
 ```shell Example
 docker run --rm \
   -v $PWD/bootstrap:/bootstrap:ro  \
   -v $PWD/data:/data:rw \
   --name flow-go \
   --network host \
-  gcr.io/flow-container-registry/access:$VERSION \ # Use the version for the current spork, from https://github.com/onflow/flow-go/releases
+  gcr.io/flow-container-registry/access:v0.32.4 \
   --nodeid=e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5 \
   --bootstrapdir=/bootstrap \
   --datadir=/data/protocol \

--- a/docs/networks/node-ops/nodes/node-operation/access-node-setup.md
+++ b/docs/networks/node-ops/nodes/node-operation/access-node-setup.md
@@ -257,7 +257,7 @@ If your node was selected as part of Step 3, you can now start your node.
 
 First you'll need to provision a machine or virtual machine to run your node software. Please see follow the [node-provisioning](./node-provisioning.md) guide for it.
 
-The access node can be run as a docker container with the following command by replacing `nodeid` with your node ID and adjusting the other parameters as per your setup. 
+The access node can be run as a Docker container with the following command.
 
 Be sure to set `$VERSION` below to the version tag (eg. `v1.2.3`) corresponding to the current network version (see [here](https://github.com/onflow/flow-go/releases) for version releases). Set `$NODEID` to your node's ID (see [Generate Your Node Identity](#generate-your-node-identity) section above).
 

--- a/docs/networks/node-ops/nodes/node-operation/access-node-setup.md
+++ b/docs/networks/node-ops/nodes/node-operation/access-node-setup.md
@@ -257,7 +257,9 @@ If your node was selected as part of Step 3, you can now start your node.
 
 First you'll need to provision a machine or virtual machine to run your node software. Please see follow the [node-provisioning](./node-provisioning.md) guide for it.
 
-The access node can be run as a docker container with the following command by replacing `nodeid` with your node ID and adjusting the other parameters as per your setup.
+The access node can be run as a docker container with the following command by replacing `nodeid` with your node ID and adjusting the other parameters as per your setup. 
+
+Be sure to use the version tag corresponding to the current network version (see [here](https://github.com/onflow/flow-go/releases) for version releases).
 
 ```shell
 docker run --rm \
@@ -265,7 +267,7 @@ docker run --rm \
   -v $PWD/data:/data:rw \
   --name flow-go \
   --network host \
-  gcr.io/flow-container-registry/access:v0.29.8 \
+  gcr.io/flow-container-registry/access:$VERSION \ # Use the version for the current spork, from https://github.com/onflow/flow-go/releases
   --nodeid=[Insert you NODE ID here] \
   --bootstrapdir=/bootstrap \
   --datadir=/data/protocol \
@@ -288,7 +290,7 @@ docker run --rm \
   -v $PWD/data:/data:rw \
   --name flow-go \
   --network host \
-  gcr.io/flow-container-registry/access:v0.29.8 \
+  gcr.io/flow-container-registry/access:$VERSION \ # Use the version for the current spork, from https://github.com/onflow/flow-go/releases
   --nodeid=e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5 \
   --bootstrapdir=/bootstrap \
   --datadir=/data/protocol \

--- a/docs/networks/node-ops/nodes/node-operation/access-node-setup.md
+++ b/docs/networks/node-ops/nodes/node-operation/access-node-setup.md
@@ -290,7 +290,7 @@ docker run --rm \
   -v $PWD/data:/data:rw \
   --name flow-go \
   --network host \
-  gcr.io/flow-container-registry/access:v0.32.4 \
+  gcr.io/flow-container-registry/access:v1.2.3 \
   --nodeid=e737ec6efbd26ef43bf676911cdc5a11ba15fc6562d05413e6589fccdd6c06d5 \
   --bootstrapdir=/bootstrap \
   --datadir=/data/protocol \


### PR DESCRIPTION
Remove the hard-coded version and point to the list of available releases. (Is there a better place where we have a mapping from network/spork number to software version?)

Also correct the permissionless AN FAQ to link to permissionless AN doc page rather than say it is coming soon.