### PR TITLE
Updating the page that describes Scripts

### DIFF
--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -63,7 +63,7 @@ Scripts can be used for the following:
 
 ### Access API
 
-A Script can be executed by being submitted it to the Access Node APIs provided by the access nodes. Currently, there’s support for three APIs which allows a user to execute script at the latest sealed block or a previous block height or previous block ID.
+A script can be executed by submitting it to the Access API provided by access nodes. Currently, there are three API endpoints that allow a user to execute scripts at the latest sealed block, a previous block height, or a previous block ID.
 
 [**gRPC Script API**](../../networks/node-ops/access-onchain-data/access-nodes/accessing-data/access-api.md#scripts)
 

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -92,7 +92,7 @@ A user can define their own scripts or can use already defined scripts by the co
 1. **Rate limit** - Script execution is subjected to API rate-limits imposed by the Access nodes and the Execution nodes. The rate limits for the Public Access nodes hosted by QuickNode are outlined [here](https://www.quicknode.com/docs/flow#endpoint-rate-limits).
 
 
-2. **Computation limit** - Similar to a transaction, each script is also subjected to a computation limit. Currently, the compute (gas) limit for a script is 100,000.
+2. **Computation limit** - Similar to a transaction, each script is also subjected to a computation limit. The specific value can be configured by individual Access and Execution node operators. Currently, the default compute (gas) limit for a script is 100,000.
 
 
 3. **Historic block data limit**

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -22,7 +22,7 @@ pub fun main() {
 }
 ```
 
-Scripts can return a typed value.
+Scripts can return a typed value:
 
 ```cadence
 pub fun main(): Int {
@@ -30,7 +30,7 @@ pub fun main(): Int {
 }
 ```
 
-Scripts can also accept arguments.
+Scripts can also accept arguments:
 
 ```cadence
 pub fun main(arg: String): String {

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -96,7 +96,7 @@ A user can define their own scripts or can use already defined scripts by the co
 
 
 3. **Historic block data limit**
-   1. Script execution on the execution node is restricted to approximately the last 600 blocks. Any request for script execution on an execution node on a past block (specified by block ID or block height) will fail if that block is more than 600 blocks in the past.
+   1. Script execution on execution nodes is restricted to approximately the last 100 blocks. Any request for script execution on an execution node on a past block (specified by block ID or block height) will fail if that block is more than 100 blocks in the past.
    2. Script execution on an access node can go much beyond the last 600 blocks but is restricted to the height when the [last](https://developers.flow.com/networks/node-ops/node-operation/past-sporks) network upgrade ([HCU](https://developers.flow.com/networks/node-ops/node-operation/hcu) or spork) occurred. 
 
 

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -4,14 +4,15 @@ sidebar_position: 4
 
 # Scripts
 
-A script is executable Cadence code that queries the Flow network but does not modify it. Unlike Flow transactions, they don’t need to be signed and require no transaction fees. Also unlike transactions, scripts can return a value. You can think of executing scripts as a read-only operation very similar to the `eth_call` RPC method on Ethereum. 
+A script is executable Cadence code that queries the Flow network but does not modify it. Unlike Flow transactions, a script is not signed and requires no transaction fees. Also unlike transactions, a script can return a value.
+You can think of executing a script as a read-only operation very similar to the `eth_call` RPC method on Ethereum.
 
-Scripts are currently executed on either the Access Nodes or the Execution Nodes based on the Access node setup.
+Scripts are currently executed on either the Access Nodes or the Execution Nodes based on the Access node configuration.
 
 Scripts are defined by following the Cadence code:
 
 ```cadence
-// The main function is the entry point function and every script needs to have one.
+// The 'main' function is the entry point function and every script needs to have one.
 pub fun main() {
  // Cadence statements to be executed go here
 }
@@ -45,9 +46,9 @@ pub fun main(): String {
 
 Scripts can also be run against previous blocks, allowing you to query historic data from the Flow network. This is particularly useful for retrieving historical states of contracts or tracking changes over time.
 
-## Why to use a script?
+## When to use a script?
 
-A script provide a light-weight method to query chain data. It can be used for the following:
+A script provides a light-weight method to query chain data. It can be used for the following:
 
 1. Validating a transaction before submitting it e.g. checking if the payer has sufficient balance, the receiver account is setup correctly to receive a token or NFT etc.
 2. Collecting chain data over time.

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -4,17 +4,20 @@ sidebar_position: 4
 
 # Scripts
 
-A script is executable Cadence code that queries the Flow network but does not modify it. Unlike Flow transactions, they don’t need signing and they can return a value. You can think of executing scripts as a read-only operation. 
+A script is executable Cadence code that queries the Flow network but does not modify it. Unlike Flow transactions, they don’t need to be signed and require no transaction fees. Also unlike transactions, scripts can return a value. You can think of executing scripts as a read-only operation very similar to the `eth_call` RPC method on Ethereum. 
 
-Scripts are executed on Access Nodes or Execution Nodes. 
+Scripts are currently executed on either the Access Nodes or the Execution Nodes based on the Access node setup.
 
-Scripts are defined by following the Cadence code and we can only execute one at a time.
+Scripts are defined by following the Cadence code:
 
 ```cadence
-pub fun main() {}
+// The main function is the entry point function and every script needs to have one.
+pub fun main() {
+ // Cadence statements to be executed go here
+}
 ```
 
-Scripts can return a typed value:
+Scripts can return a typed value.
 
 ```cadence
 pub fun main(): Int {
@@ -32,19 +35,13 @@ pub fun main(): String {
 }
 ```
 
+Scripts can also be run against previous blocks, allowing you to query historic data from the Flow network. This is particularly useful for retrieving historical states of contracts or tracking changes over time.
+
 ## Executing Scripts
 
-You can execute a script by using the Flow CLI:
+### Access API
 
-```sh
-flow scripts execute ./helloWorld.cdc
-```
-
-A user can define their own scripts or can use already defined scripts by the contract authors that can be found by using the FLIX service.
-
-Scripts can be run against previous blocks, allowing you to query historic data from the Flow network. This is particularly useful for retrieving historical states of contracts or tracking changes over time.
-
-Scripts are executed by being submitted to the Access Node APIs. Currently, there’s support for two APIs:
+A Script can be executed by being submitted it to the Access Node APIs provided by the access nodes. Currently, there’s support for three APIs which allows a user to execute script at the latest sealed block or a previous block height or previous block ID.
 
 [**gRPC Script API**](../../networks/node-ops/access-onchain-data/access-nodes/accessing-data/access-api.md#scripts)
 
@@ -57,3 +54,23 @@ There are multiple SDKs implementing the above APIs for different languages:
 [**Go SDK**](../../tools/clients/flow-go-sdk/index.mdx)
 
 Find a list of all SDKs [here](../../tools/clients/index.md)
+
+### Flow CLI
+
+You can also execute a script by using the [Flow CLI](../../tools/flow-cli/scripts/execute-scripts):
+
+```sh
+flow scripts execute ./helloWorld.cdc
+```
+
+A user can define their own scripts or can use already defined scripts by the contract authors that can be found by using the [FLIX](../../tools/flow-cli/flix) service.
+
+## Limitations
+
+1. Rate limits - Script execution is subjected to API rate-limits imposed by the Access node. The rate limits for the Public Access nodes hosted by QuickNode is available [here](https://www.quicknode.com/docs/flow#endpoint-rate-limits).
+
+2. Computation limits - Similar to a transaction, script also have computation limits. Currently, the compute (gas) limit for script is 100,000.
+
+3. Historic block data - Script execution on the execution node is restricted to approximately the last 600 blocks. Any request for script execution on an execution node by block (ID or height) will fail if the block is more than 600 blocks in the past. Script execution on an access node can go much beyond the last 600 blocks but is restricted to the height when the [last](https://developers.flow.com/networks/node-ops/node-operation/past-sporks) network upgrade ([HCU](https://developers.flow.com/networks/node-ops/node-operation/hcu) or spork) occurred. 
+
+

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -52,7 +52,7 @@ A script provide a light-weight method to query chain data. It can be used for t
 1. Validating a transaction before submitting it e.g. checking if the payer has sufficient balance, the receiver account is setup correctly to receive a token or NFT etc.
 2. Collecting chain data over time.
 3. Continuously verifying accounts through a background job e.g. a Discord bot that verifies users by their Flow account.
-4. Querying core contracts e.g. see [staking scripts and events](../../networks/staking/07-staking-scripts-events) for querying staking and epoch related information, see the scripts directory under each of the [core contract transactions](https://github.com/onflow/flow-core-contracts/tree/master/transactions) for other core contracts related scripts.
+4. Querying core contracts e.g. see [staking scripts and events](../../networks/staking/07-staking-scripts-events.md) for querying staking and epoch related information, see the scripts directory under each of the [core contract transactions](https://github.com/onflow/flow-core-contracts/tree/master/transactions) for other core contracts related scripts.
 
 ## Executing Scripts
 

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -89,7 +89,7 @@ A user can define their own scripts or can use already defined scripts by the co
 
 ## Limitations
 
-1. **Rate limit** - Script execution is subjected to API rate-limits imposed by the Access nodes and the Execution nodes. The rate limits for the Public Access nodes hosted by QuickNode are mentioned [here](https://www.quicknode.com/docs/flow#endpoint-rate-limits).
+1. **Rate limit** - Script execution is subjected to API rate-limits imposed by the Access nodes and the Execution nodes. The rate limits for the Public Access nodes hosted by QuickNode are outlined [here](https://www.quicknode.com/docs/flow#endpoint-rate-limits).
 
 
 2. **Computation limit** - Similar to a transaction, each script is also subjected to a computation limit. Currently, the compute (gas) limit for a script is 100,000.

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -45,7 +45,7 @@ pub fun main(): String {
 
 Scripts can also be run against previous blocks, allowing you to query historic data from the Flow network. This is particularly useful for retrieving historical states of contracts or tracking changes over time.
 
-## Why use a script?
+## Why to use a script?
 
 A script provide a light-weight method to query chain data. It can be used for the following:
 
@@ -84,7 +84,7 @@ A user can define their own scripts or can use already defined scripts by the co
 
 ## Limitations
 
-1. Rate limits - Script execution is subjected to API rate-limits imposed by the Access node. The rate limits for the Public Access nodes hosted by QuickNode is available [here](https://www.quicknode.com/docs/flow#endpoint-rate-limits).
+1. Rate limits - Script execution is subjected to API rate-limits imposed by the Access node. The rate limits for the Public Access nodes hosted by QuickNode are mentioned [here](https://www.quicknode.com/docs/flow#endpoint-rate-limits).
 
 2. Computation limits - Similar to a transaction, script also have computation limits. Currently, the compute (gas) limit for script is 100,000.
 

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -52,7 +52,7 @@ A script provide a light-weight method to query chain data. It can be used for t
 1. Validating a transaction before submitting it e.g. checking if the payer has sufficient balance, the receiver account is setup correctly to receive a token or NFT etc.
 2. Collecting chain data over time.
 3. Continuously verifying accounts through a background job e.g. a Discord bot that verifies users by their Flow account.
-4. Querying core contracts e.g. see [staking scripts and events](../..//networks/staking/staking-scripts-events) for querying staking and epoch related information, see the scripts directory under each of the [core contract transactions](https://github.com/onflow/flow-core-contracts/tree/master/transactions) for other core contracts related scripts.
+4. Querying core contracts e.g. see [staking scripts and events](../../networks/staking/07-staking-scripts-events) for querying staking and epoch related information, see the scripts directory under each of the [core contract transactions](https://github.com/onflow/flow-core-contracts/tree/master/transactions) for other core contracts related scripts.
 
 ## Executing Scripts
 

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -25,6 +25,14 @@ pub fun main(): Int {
 }
 ```
 
+Scripts can accept arguments.
+
+```cadence
+pub fun main(arg: String): String {
+	return "Hello ".concat(arg)
+}
+```
+
 Scripts can call contract functions and query the state of a contract. To call a function on another contract, import it from its address and invoke the function:
 
 ```cadence
@@ -36,6 +44,15 @@ pub fun main(): String {
 ```
 
 Scripts can also be run against previous blocks, allowing you to query historic data from the Flow network. This is particularly useful for retrieving historical states of contracts or tracking changes over time.
+
+## Why use a script?
+
+A script provide a light-weight method to query chain data. It can be used for the following:
+
+1. Validating a transaction before submitting it e.g. checking if the payer has sufficient balance, the receiver account is setup correctly to receive a token or NFT etc.
+2. Collecting chain data over time.
+3. Continuously verifying accounts through a background job e.g. a Discord bot that verifies users by their Flow account.
+4. Querying core contracts e.g. see [staking scripts and events](../..//networks/staking/staking-scripts-events) for querying staking and epoch related information, see the scripts directory under each of the [core contract transactions](https://github.com/onflow/flow-core-contracts/tree/master/transactions) for other core contracts related scripts.
 
 ## Executing Scripts
 

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -6,12 +6,14 @@ sidebar_position: 4
 
 A script provides a light-weight method to query chain data.
 
-It is an executable Cadence code that can query for Flow execution state data but cannot modify it in any way. Unlike Flow transactions, a script is not signed and requires no transaction fees. Also unlike transactions, a script can return a value.
+It is an executable Cadence code that can query for Flow execution state data but cannot modify it in any way.
+
+Unlike a Flow transaction, a script is not signed and requires no transaction fees. Also unlike a transaction, a script can return a value back to the caller.
 You can think of executing a script as a read-only operation, very similar to the `eth_call` RPC method on Ethereum.
 
 Scripts are currently executed on either the Access Nodes or the Execution Nodes based on the Access node configuration.
 
-Scripts are defined by following the Cadence code:
+Scripts are defined by the following the Cadence code:
 
 ```cadence
 // The 'main' function is the entry point function and every script needs to have one.

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -4,7 +4,9 @@ sidebar_position: 4
 
 # Scripts
 
-A script is executable Cadence code that queries the Flow network but does not modify it. Unlike Flow transactions, a script is not signed and requires no transaction fees. Also unlike transactions, a script can return a value.
+A script provides a light-weight method to query chain data.
+
+It is an executable Cadence code that can query for Flow execution state data but not modify it. Unlike Flow transactions, a script is not signed and requires no transaction fees. Also unlike transactions, a script can return a value.
 You can think of executing a script as a read-only operation very similar to the `eth_call` RPC method on Ethereum.
 
 Scripts are currently executed on either the Access Nodes or the Execution Nodes based on the Access node configuration.
@@ -48,7 +50,7 @@ Scripts can also be run against previous blocks, allowing you to query historic 
 
 ## When to use a script?
 
-A script provides a light-weight method to query chain data. It can be used for the following:
+Scripts can be used for the following:
 
 1. Validating a transaction before submitting it e.g. checking if the payer has sufficient balance, the receiver account is setup correctly to receive a token or NFT etc.
 2. Collecting chain data over time.

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 A script provides a light-weight method to query chain data.
 
-It is an executable Cadence code that can query for Flow execution state data but cannot modify it in any way.
+It is executable Cadence code that can query for Flow execution state data but cannot modify it in any way.
 
 Unlike a Flow transaction, a script is not signed and requires no transaction fees. Also unlike a transaction, a script can return a value back to the caller.
 You can think of executing a script as a read-only operation, very similar to the `eth_call` RPC method on Ethereum.

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -97,6 +97,6 @@ A user can define their own scripts or can use already defined scripts by the co
 
 3. **Historic block data limit**
    1. Script execution on execution nodes is restricted to approximately the last 100 blocks. Any request for script execution on an execution node on a past block (specified by block ID or block height) will fail if that block is more than 100 blocks in the past.
-   2. Script execution on an access node can go much beyond the last 600 blocks but is restricted to the height when the [last](https://developers.flow.com/networks/node-ops/node-operation/past-sporks) network upgrade ([HCU](https://developers.flow.com/networks/node-ops/node-operation/hcu) or spork) occurred. 
+   2. Script execution on an access node can go much beyond the last 100 blocks but is restricted to the height when the [last](https://developers.flow.com/networks/node-ops/node-operation/past-sporks) network upgrade ([HCU](https://developers.flow.com/networks/node-ops/node-operation/hcu) or spork) occurred. 
 
 

--- a/docs/build/basics/scripts.md
+++ b/docs/build/basics/scripts.md
@@ -6,8 +6,8 @@ sidebar_position: 4
 
 A script provides a light-weight method to query chain data.
 
-It is an executable Cadence code that can query for Flow execution state data but not modify it. Unlike Flow transactions, a script is not signed and requires no transaction fees. Also unlike transactions, a script can return a value.
-You can think of executing a script as a read-only operation very similar to the `eth_call` RPC method on Ethereum.
+It is an executable Cadence code that can query for Flow execution state data but cannot modify it in any way. Unlike Flow transactions, a script is not signed and requires no transaction fees. Also unlike transactions, a script can return a value.
+You can think of executing a script as a read-only operation, very similar to the `eth_call` RPC method on Ethereum.
 
 Scripts are currently executed on either the Access Nodes or the Execution Nodes based on the Access node configuration.
 
@@ -28,7 +28,7 @@ pub fun main(): Int {
 }
 ```
 
-Scripts can accept arguments.
+Scripts can also accept arguments.
 
 ```cadence
 pub fun main(arg: String): String {
@@ -87,10 +87,14 @@ A user can define their own scripts or can use already defined scripts by the co
 
 ## Limitations
 
-1. Rate limits - Script execution is subjected to API rate-limits imposed by the Access node. The rate limits for the Public Access nodes hosted by QuickNode are mentioned [here](https://www.quicknode.com/docs/flow#endpoint-rate-limits).
+1. **Rate limit** - Script execution is subjected to API rate-limits imposed by the Access nodes and the Execution nodes. The rate limits for the Public Access nodes hosted by QuickNode are mentioned [here](https://www.quicknode.com/docs/flow#endpoint-rate-limits).
 
-2. Computation limits - Similar to a transaction, script also have computation limits. Currently, the compute (gas) limit for script is 100,000.
 
-3. Historic block data - Script execution on the execution node is restricted to approximately the last 600 blocks. Any request for script execution on an execution node by block (ID or height) will fail if the block is more than 600 blocks in the past. Script execution on an access node can go much beyond the last 600 blocks but is restricted to the height when the [last](https://developers.flow.com/networks/node-ops/node-operation/past-sporks) network upgrade ([HCU](https://developers.flow.com/networks/node-ops/node-operation/hcu) or spork) occurred. 
+2. **Computation limit** - Similar to a transaction, each script is also subjected to a computation limit. Currently, the compute (gas) limit for a script is 100,000.
+
+
+3. **Historic block data limit**
+   1. Script execution on the execution node is restricted to approximately the last 600 blocks. Any request for script execution on an execution node on a past block (specified by block ID or block height) will fail if that block is more than 600 blocks in the past.
+   2. Script execution on an access node can go much beyond the last 600 blocks but is restricted to the height when the [last](https://developers.flow.com/networks/node-ops/node-operation/past-sporks) network upgrade ([HCU](https://developers.flow.com/networks/node-ops/node-operation/hcu) or spork) occurred. 
 
 


### PR DESCRIPTION
This is in preparation for the launch of Script execution on AN.

Current page: https://developers.flow.com/build/basics/scripts
Updated page: https://docs-git-vishal-scripts-onflow.vercel.app/build/basics/scripts