### PR TITLE
Adjusting the machine account creation instructions in the node bootstrap guide 

### DIFF
--- a/docs/networks/flow-port/staking-guide.md
+++ b/docs/networks/flow-port/staking-guide.md
@@ -62,18 +62,6 @@ If you return to the home screen, you'll be able to see your staking request in 
 
 ![Flow Port Staking](port-stake-4.png)
 
-### Existing Node Operators
-
-If you are already a node operator with a staked node, you will first need to upgrade your account to a Staking Collection. On the Stake & Delegate page you will see a card which will walk you through submitting the transaction to upgrade your account to Staking Collection.
-
-![Flow Port Staking](staking-collection.png)
-
-Once this is done, you can now create a [Machine Account](../../networks/node-ops/node-operation/machine-existing-operator.md) by clicking the "Upgrade Node" button on the Stake & Delegate page.
-
-![Flow Port Staking](machine-account.png)
-
-You can follow the guide [here](../../networks/node-ops/node-operation/machine-existing-operator.md) to create your Machine Account.
-
 ## Delegating
 
 Delegating is the process of staking your locked FLOW to nodes which are being run by another party.

--- a/docs/networks/node-ops/node-operation/node-bootstrap.md
+++ b/docs/networks/node-ops/node-operation/node-bootstrap.md
@@ -178,6 +178,8 @@ $cat ./bootstrap/public-root-information/node-info.pub.39fa54984b8eaa463e1299194
 If you are running a collection or consensus node, you will need to provide an additional field `Machine Account Public Key`.
 This value is found in the output of the `bootstrap key` command from Step 1.
 
+Staking a collection or consensus node will also create a machine account for the node. The machine account will be mentioned in the output of the staking transaction displayed by Flow Port. Pleaes save the machine account for the next step.
+
 <Callout type="info">
 
 Please let us know your node id via discord or email.

--- a/docs/networks/node-ops/node-operation/node-bootstrap.md
+++ b/docs/networks/node-ops/node-operation/node-bootstrap.md
@@ -178,7 +178,7 @@ $cat ./bootstrap/public-root-information/node-info.pub.39fa54984b8eaa463e1299194
 If you are running a collection or consensus node, you will need to provide an additional field `Machine Account Public Key`.
 This value is found in the output of the `bootstrap key` command from Step 1.
 
-Staking a collection or consensus node will also create a machine account for the node. The machine account will be mentioned in the output of the staking transaction displayed by Flow Port. Pleaes save the machine account for the next step.
+Staking a collection or consensus node will also create a machine account for the node. The machine account will be mentioned in the output of the staking transaction displayed by Flow Port. Please save the machine account for the next step.
 
 <Callout type="info">
 

--- a/docs/networks/staking/11-machine-account.md
+++ b/docs/networks/staking/11-machine-account.md
@@ -23,9 +23,7 @@ Currently Machine Accounts are required only for `collection` and `consensus` no
 
 #### Creation
 
-For new node operators, Machine Accounts are created during the [staking process](../../networks/flow-port/staking-guide.md) in Flow Port.
-For node operators who initially staked prior to the introduction of Machine Accounts, Machine Accounts can be
-created for your staked nodes by following [this guide](../node-ops/node-operation/machine-existing-operator.md).
+Machine Accounts are created during the [staking process](../../networks/flow-port/staking-guide.md) in Flow Port.
 
 #### Funding
 


### PR DESCRIPTION
1. removing instructions for _existing_ node operators to create a machine account since all LN and SN operators have already done that.
2. Adding a line for _new_ SN and LN NO to take note of the machine account when staking.