### PR TITLE
legacy info

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -627,6 +627,29 @@ const config = {
         },
       },
     ],
+    function InsertInfoTagForCadence() {
+      return {
+        name: 'docusaurus-plugin-insert-info-tags',
+        configureWebpack(config, isServer, utils) {
+          return {
+            module: {
+              rules: [
+                {
+                  test: /\.md$/,
+                  use: [
+                    {
+                      loader: require.resolve(
+                        './src/plugins/insert-info-tags-loader.js',
+                      ),
+                    },
+                  ],
+                },
+              ],
+            },
+          };
+        },
+      };
+    },
   ],
   stylesheets: [
     {

--- a/src/plugins/insert-info-tags-loader.js
+++ b/src/plugins/insert-info-tags-loader.js
@@ -8,8 +8,17 @@ module.exports = function (source) {
 
   // Function to insert :::info::: tag into content
   const insertInfoTag = (content) => {
-    // Insert :::info::: tag at the beginning of the content
-    return ':::info\n' + infoBannerMessage + '\n:::\n' + content;
+    const infoBanner = ':::info\n' + infoBannerMessage + '\n:::\n';
+    // Check fof front matter
+    if (!content.startsWith('---\n')) {
+      // Insert :::info::: tag at the beginning of the content
+      return infoBanner + content;
+    }
+    // Split the content into front matter and body
+    const [frontMatter, ...body] = content.split('---\n').slice(1);
+
+    // Insert :::info::: tag after front matter
+    return `---\n${frontMatter}---\n${infoBanner}${body.join('---\n')}`;
   };
 
   // Check if the content contains a "cadence" code block

--- a/src/plugins/insert-info-tags-loader.js
+++ b/src/plugins/insert-info-tags-loader.js
@@ -1,0 +1,23 @@
+module.exports = function (source) {
+  const infoBannerMessage =
+    'For Cadence 0.42 go to [Legacy Docs](https://legacy.developers.flow.com/)';
+  // Function to check if a page content contains "cadence" code block
+  const containsCadenceCodeBlock = (content) => {
+    return content.includes('```cadence');
+  };
+
+  // Function to insert :::info::: tag into content
+  const insertInfoTag = (content) => {
+    // Insert :::info::: tag at the beginning of the content
+    return ':::info\n' + infoBannerMessage + '\n:::\n' + content;
+  };
+
+  // Check if the content contains a "cadence" code block
+  if (containsCadenceCodeBlock(source)) {
+    // Insert :::info::: tag
+    return insertInfoTag(source);
+  }
+
+  // Return the original content if no changes are needed
+  return source;
+};


### PR DESCRIPTION
dynamically add legacy info link to pages with cadence code snippets
Example:
https://docs-git-nialexsan-dynamic-legacy-info-onflow.vercel.app/build/smart-contracts/testing