### PR TITLE
Updates various docs for Cadence 1.0

### DIFF
--- a/docs/build/basics/accounts.md
+++ b/docs/build/basics/accounts.md
@@ -162,7 +162,12 @@ The Service Account has administrator access to the FLOW token smart contract, s
 The Service Account administers other smart contracts that manage various aspects of the Flow network, such as epochs and (in the future) validator staking auctions.
 
 ### Governance
-Besides its special permissions, the Service Account is an account like any other in Flow. During the early phases of Flow's development, the account will be controlled by keys held by Dapper Labs. As Flow matures, the service account will transition to being controlled by a smart contract governed by the Flow community.
+Besides its special permissions, the Service Account is an account like any other in Flow.
+The service account is currently controlled by a smart contract governed by the Flow community.
+No single entity has the ability to unilaterally execute a transaction
+from the service account because it requires four signatures from controlling keys.
+The Flow foundation only controls 3 of the keys and the others are controlled
+by trusted community members and organizations.
 
 
 ## Accounts Retrieval

--- a/docs/build/basics/events.md
+++ b/docs/build/basics/events.md
@@ -79,9 +79,9 @@ event Withdrawn(type: String,
                 balanceAfter: UFix64)
 ```
 
-Mainnet event: `A.0xf233dcee88fe0abe.FungibleToken.Withdrawn`
+Mainnet event: `A.f233dcee88fe0abe.FungibleToken.Withdrawn`
 
-Testnet event: `A.0x9a0766d93b6608b7.FungibleToken.Withdrawn`
+Testnet event: `A.9a0766d93b6608b7.FungibleToken.Withdrawn`
 
 **Deposit Tokens**
 
@@ -96,9 +96,9 @@ event Deposited(type: String,
 
 Event name: `FungibleToken.Deposited`
 
-Mainnet event: `A.0xf233dcee88fe0abe.FungibleToken.Deposited`
+Mainnet event: `A.f233dcee88fe0abe.FungibleToken.Deposited`
 
-Testnet event: `A.0x9a0766d93b6608b7.FungibleToken.Deposited`
+Testnet event: `A.9a0766d93b6608b7.FungibleToken.Deposited`
 
 ### **Fee Events**
 
@@ -117,20 +117,20 @@ An example of fee events:
 ```yml
 Events:
   - Index: 0
-    Type:  A.0xf233dcee88fe0abe.FungibleToken.Withdrawn
+    Type:  A.f233dcee88fe0abe.FungibleToken.Withdrawn
     Tx ID: 1ec90051e3bc74fc36cbd16fc83df08e463dda8f92e8e2193e061f9d41b2ad92
     Values:
-      - type (String): "0x1654653399040a61.FlowToken.Vault"
+      - type (String): "1654653399040a61.FlowToken.Vault"
       - amount (UFix64): 0.00000100
-      - from (Address?): 0xb30eb2755dca4572
+      - from (Address?): b30eb2755dca4572
 
   - Index: 1
-    Type:  A.0xf233dcee88fe0abe.FungibleToken.Deposited
+    Type:  A.f233dcee88fe0abe.FungibleToken.Deposited
     Tx ID: 1ec90051e3bc74fc36cbd16fc83df08e463dda8f92e8e2193e061f9d41b2ad92
     Values:
-      - type (String): "0x1654653399040a61.FlowToken.Vault"
+      - type (String): "1654653399040a61.FlowToken.Vault"
       - amount (UFix64): 0.00000100
-      - to (Address?): 0xf919ee77447b7497
+      - to (Address?): f919ee77447b7497
 
   - Index: 2
     Type:  A.f919ee77447b7497.FlowFees.FeesDeducted

--- a/docs/build/basics/events.md
+++ b/docs/build/basics/events.md
@@ -57,27 +57,48 @@ The first `A` means the event is originating from a contract, which will always 
 
 There is an unlimited amount of events that can be defined on Flow, but you should know about the most common ones. 
 
-### FLOW Token Events
+### Fungible Token Events
 
-The FLOW Token contract uses the [fungible token standard on Flow](../../build/core-contracts/03-flow-token.md) and is the contract that issues a core FLOW token. As with any contract, it can emit events when interacted with. When we transfer the FLOW token, events are emitted. You can find a lot of details on the events emitted in the [FLOW Token documentation](../../build/core-contracts/03-flow-token.md). 
+All fungible token contracts, including [The FLOW Token contract](../../build/core-contracts/03-flow-token.md),
+use the [fungible token standard on Flow](../../build/core-contracts/02-fungible-token.md).
+As with any contract, the standard emits events when interacted with.
+When any fungible token is transferred, standard events are emitted.
+You can find a lot of details on the events emitted in the [Fungible Token documentation](../../build/core-contracts/02-fungible-token.md). 
 
-The most common events are when tokens are transferred which is accomplished with two actions: withdrawing tokens from the payer and depositing tokens in the receiver. Each of those action has a corresponding event:
+The most common events are when tokens are transferred which is accomplished with two actions: withdrawing tokens from the payer and depositing tokens in the receiver. Each of those actions has a corresponding event:
 
 **Withdraw Tokens**
 
-Event name: `TokensWithdrawn`
+Event name: `FungibleToken.Withdrawn`
+```cadence
+event Withdrawn(type: String,
+                amount: UFix64,
+                from: Address?,
+                fromUUID: UInt64,
+                withdrawnUUID: UInt64,
+                balanceAfter: UFix64)
+```
 
-Mainnet event: `A.1654653399040a61.FlowToken.TokensWithdrawn`
+Mainnet event: `A.0xf233dcee88fe0abe.FungibleToken.Withdrawn`
 
-Testnet event: `A.7e60df042a9c0868.FlowToken.TokensWithdrawn`
+Testnet event: `A.0x9a0766d93b6608b7.FungibleToken.Withdrawn`
 
 **Deposit Tokens**
 
-Event name: `TokensDeposited`
+```cadence
+event Deposited(type: String,
+                amount: UFix64,
+                to: Address?,
+                toUUID: UInt64,
+                depositedUUID: UInt64,
+                balanceAfter: UFix64)
+```
 
-Mainnet event: `A.1654653399040a61.FlowToken.TokensDeposited`
+Event name: `FungibleToken.Deposited`
 
-Testnet event: `A.7e60df042a9c0868.FlowToken.TokensDeposited`
+Mainnet event: `A.0xf233dcee88fe0abe.FungibleToken.Deposited`
+
+Testnet event: `A.0x9a0766d93b6608b7.FungibleToken.Deposited`
 
 ### **Fee Events**
 
@@ -96,16 +117,18 @@ An example of fee events:
 ```yml
 Events:
   - Index: 0
-    Type:  A.1654653399040a61.FlowToken.TokensWithdrawn
+    Type:  A.0xf233dcee88fe0abe.FungibleToken.Withdrawn
     Tx ID: 1ec90051e3bc74fc36cbd16fc83df08e463dda8f92e8e2193e061f9d41b2ad92
     Values:
+      - type (String): "0x1654653399040a61.FlowToken.Vault"
       - amount (UFix64): 0.00000100
       - from (Address?): 0xb30eb2755dca4572
 
   - Index: 1
-    Type:  A.1654653399040a61.FlowToken.TokensDeposited
+    Type:  A.0xf233dcee88fe0abe.FungibleToken.Deposited
     Tx ID: 1ec90051e3bc74fc36cbd16fc83df08e463dda8f92e8e2193e061f9d41b2ad92
     Values:
+      - type (String): "0x1654653399040a61.FlowToken.Vault"
       - amount (UFix64): 0.00000100
       - to (Address?): 0xf919ee77447b7497
 

--- a/docs/build/basics/fees.md
+++ b/docs/build/basics/fees.md
@@ -308,10 +308,10 @@ Avoid costly loading and storage operations and [borrow references](https://cade
 ```cadence
 transaction {
 
-    prepare(acct: AuthAccount) {
+    prepare(acct: auth(BorrowValue) &Account) {
 
         // Borrows a reference to the stored vault, much less costly operation that removing the vault from storage
-        let vault <- acct.borrow<&ExampleToken.Vault>(from: /storage/exampleToken)
+        let vault <- acct.storage.borrow<&ExampleToken.Vault>(from: /storage/exampleToken)
 
         let burnVault <- vault.withdraw(amount: 10)
 

--- a/docs/build/basics/flow-token.md
+++ b/docs/build/basics/flow-token.md
@@ -84,7 +84,7 @@ The protocol requires some FLOW tokens to process these transactions,
 but (and this is the cool part!) a product can support users who do not themselves hold FLOW
 while still providing that user with all the underlying security guarantees the Flow protocol provides.
 
-Transferring FLOW, creating accounts, and updating keys are all actions made easy on [Flow Port](https://port.onflow.org/)
+Transferring FLOW, creating accounts, and updating keys are all actions made easy on [Flow Port](https://port.flow.com/)
 
 ### Submitting Transactions and Updating Users
 

--- a/docs/build/basics/transactions.md
+++ b/docs/build/basics/transactions.md
@@ -74,11 +74,11 @@ Example transaction with multiple authorizers:
 
 ```cadence
 transaction {
-  prepare(authorizer1: AuthAccount, authorizer2: AuthAccount) { }
+  prepare(authorizer1: auth(Capabilities) &Account, authorizer2: auth(Storage) &Account) { }
 }
 ```
 
-Each account defined as an authorizer must sign the transaction with its own key, and by doing so it acknowledges the transaction it signed will have access to that account and may modify it. How it will modify it is understood from reading the transaction script.
+Each account defined as an authorizer must sign the transaction with its own key, and by doing so it acknowledges the transaction it signed will have access to that account and may modify it. How it will modify it is understood from the list of account entitlements that are granted in the `prepare` argument list and by reading the transaction script.
 
 **Payer**
 

--- a/docs/build/basics/transactions.md
+++ b/docs/build/basics/transactions.md
@@ -78,7 +78,15 @@ transaction {
 }
 ```
 
-Each account defined as an authorizer must sign the transaction with its own key, and by doing so it acknowledges the transaction it signed will have access to that account and may modify it. How it will modify it is understood from the list of account entitlements that are granted in the `prepare` argument list and by reading the transaction script.
+Each account defined as an authorizer must sign the transaction with its own key,
+and by doing so it acknowledges the transaction it signed
+will have access to that account and may modify it.
+How it will modify it is understood from the list of account entitlements
+that are granted in the `prepare` argument list and by reading the transaction script.
+In an transaction, developers should only give the minimum set of account entitlements
+that are required for the transaction to execute properly.
+This ensures that users who are signing transactions can understand
+what parts of their account a transaction can access.
 
 **Payer**
 

--- a/docs/build/differences-vs-evm/index.md
+++ b/docs/build/differences-vs-evm/index.md
@@ -30,7 +30,7 @@ Check out the [Accounts](../basics/accounts.md) concept document to learn more a
 On Flow, smart contracts are written in Cadence. Cadence syntax is user-friendly and inspired by modern languages like Swift. Notable features of Cadence that make it unique and the key power of the Flow blockchain are:
 
 - **Resource-oriented**: Cadence introduces a new type called Resources. Resources enable onchain representation of digital assets natively and securely. Resources can only exist in one location at a time and are strictly controlled by the execution environment to avoid common mishandling mistakes. Each resource has a unique `uuid` associated with it on the blockchain. Examples of usage are fungible tokens, NFTs, or any custom data structure representing a real-world asset. Check out [Resources](https://cadence-lang.org/docs/language/resources) to learn more.
-- **Capability-based**: Cadence offers a [Capability-based Security](https://en.wikipedia.org/wiki/Capability-based_security) model. This also enables the use of Resources as structures to build access control. Capabilities can provide fine-grained access to the underlying objects for better security. For example, when users list an NFT on a Flow marketplace, they create a new Capability to the stored NFT in their account so the buyer can withdraw the asset when they provide the tokens. Check out [Capability-based Access Control](https://cadence-lang.org/docs/language/capabilities) to learn more about Capabilities on Cadence.
+- **Capability-based**: Cadence offers a [Capability-based Security](https://en.wikipedia.org/wiki/Capability-based_security) model. This also enables the use of Resources as structures to build access control. Capabilities and [Entitlements](https://cadence-lang.org/docs/1.0/language/access-control#entitlements) can provide fine-grained access to the underlying objects for better security. For example, when users list an NFT on a Flow marketplace, they create a new Capability to the stored NFT in their account so the buyer can withdraw the asset when they provide the tokens. Check out [Capability-based Access Control](https://cadence-lang.org/docs/language/capabilities) to learn more about Capabilities on Cadence.
 
 <Callout type="info">
 
@@ -73,14 +73,14 @@ transaction(recipient: Address) {
     /// Previous NFT ID before the transaction executes
     let mintingIDBefore: UInt64
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: &Account) {
 
         self.mintingIDBefore = ExampleNFT.totalSupply
 
         // Borrow the recipient's public NFT collection reference
         self.recipientCollectionRef = getAccount(recipient)
-            .getCapability(ExampleNFT.CollectionPublicPath)
-            .borrow<&{NonFungibleToken.CollectionPublic}>()
+            .capabilities.get<&{NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)
+            .borrow()
             ?? panic("Could not get receiver reference to the NFT Collection")
 
     }
@@ -127,8 +127,8 @@ access(all) fun main(address: Address, collectionPublicPath: PublicPath): [UInt6
     let account = getAccount(address)
 
     let collectionRef = account
-        .getCapability(collectionPublicPath)
-        .borrow<&{NonFungibleToken.CollectionPublic}>()
+        .capabilities.get<&{NonFungibleToken.CollectionPublic}>(collectionPublicPath)
+        .borrow()
         ?? panic("Could not borrow capability from public collection at specified path")
 
     return collectionRef.getIDs()

--- a/docs/build/smart-contracts/best-practices/project-development-tips.md
+++ b/docs/build/smart-contracts/best-practices/project-development-tips.md
@@ -39,7 +39,7 @@ and more vibrant community.
 Ensuring appropriate levels of testing results in better smart contracts which have
 pro-actively modeled threats and engineered against them. Ensuring appropriate levels 
 of standards adoption ([FungibleToken](https://github.com/onflow/flow-ft),
-[NFT Catalog](https://www.flow-nft-catalog.com/), [NFT StoreFront](https://github.com/onflow/nft-storefront), etc) by dapp 
+[NFT Metadata](../../advanced-concepts/metadata-views.md), [NFT StoreFront](https://github.com/onflow/nft-storefront), etc) by dapp 
 builders amplifies the network effects for all in the ecosystem. NFTs in one dapp can be 
 readily consumed by other dapps through on-chain events with no new integration 
 required. With your help and participation we can further accelerate healthy and vibrant 
@@ -172,14 +172,12 @@ Summarized below is a list of testing related recommendations
 which are noteworthy to mention for a typical smart contract project.
 
 Popular testing frameworks to use for cadence are listed here:
+- Cadence: [Cadence Testing Framework](../../smart-contracts/testing.md)
 - Javascript: [Flow JS Testing](../../../tools/flow-js-testing/index.md)
 - Go: [Overflow](https://github.com/bjartek/overflow)
-- Cadence: [Cadence Testing Framework](../../smart-contracts/testing.md)
-Tests written in Cadence!
 
 The same person who writes the code should also write the tests.
 They have the clearest understanding of the code paths and edge cases.
-
 
 Tests should be **mandatory**, not optional, even if the contract is copied from somewhere else.
 There should be thorough emulator unit tests in the public repo.
@@ -190,12 +188,8 @@ for an example of unit tests in javascript.
 Every time there is a new Cadence version or emulator version,
 the dependencies of the repo should be updated to make sure the tests are all still passing.
 
-
 Tests should avoid being monolithic;
 Individual test cases should be set up for each part of the contract to test them in isolation. 
-See the [`FlowEpoch` smart contract tests](https://github.com/onflow/flow-core-contracts/blob/master/lib/go/test/flow_epoch_test.go)
-for examples written in Go where test cases are split
-into separate blocks for different features.
 There are some exceptions, like contracts that have to run through a state machine
 to test different cases. Positive and negative cases need to be tested.
 
@@ -296,7 +290,5 @@ Resources for Best Practices:
 
 Composability and extensibility should also be priorities while designing, developing,
 and documenting their projects. (Documentation for these topics coming soon)
-
-
 
 If you have any feedback about these guidelines, please create an issue in the onflow/cadence-style-guide repo or make a PR updating the guidelines so we can start a discussion.

--- a/docs/build/smart-contracts/best-practices/security-best-practices.md
+++ b/docs/build/smart-contracts/best-practices/security-best-practices.md
@@ -38,7 +38,7 @@ It is preferable to use capabilities over direct `&Account` references when expo
 
 ## Capabilities
 
-Don’t store anything under the [public capability storage](https://cadence-lang.org/docs/language/capabilities) unless strictly required. Anyone can access your public capability using `AuthAccount.capabilities.get`. If something needs to be stored under `/public/`, make sure only read functionality is provided by restricting privileged functions with entitlements.
+Don’t store anything under the [public capability storage](https://cadence-lang.org/docs/language/capabilities) unless strictly required. Anyone can access your public capability using `Account.capabilities.get`. If something needs to be stored under `/public/`, make sure only read functionality is provided by restricting privileged functions with entitlements.
 
 When publishing a capability, the capability might already be present at the given `PublicPath`.
 In that case, Cadence will panic with a runtime error to not override the already published capability.

--- a/docs/build/smart-contracts/best-practices/security-best-practices.md
+++ b/docs/build/smart-contracts/best-practices/security-best-practices.md
@@ -12,11 +12,14 @@ Some practices listed below might overlap with advice in the [Cadence Anti-Patte
 
 [References](https://cadence-lang.org/docs/language/references) are ephemeral values and cannot be stored. If persistence is required, store a capability and borrow it when needed.
 
-Authorized references (references with the `auth` keyword) allow downcasting, e.g. a restricted type to its unrestricted type and should only be used in some specific cases.
+References allow freely upcasting and downcasting, e.g. a restricted type can be cast to its unrestricted type which will expose all `access(all)` functions and fields of the type.
+So even if your capability uses an interface to restrict its functionality, it can
+still be downcasted to expose all other public functionality.
 
-When exposing functionality, provide the least access necessary. Do not use authorized references, as they can be downcasted, potentially allowing a user to gain access to supposedly restricted functionality. For example, the fungible token standard provides an interface to get the balance of a vault, without exposing the withdrawal functionality.
-
-Be aware that the subtype or unrestricted type could expose functionality that was not intended to be exposed. Do not use authorized references when exposing functionality. For example, the fungible token standard provides an interface to get the balance of a vault, without exposing the withdrawal functionality.
+Therefore, any privileged functionality in a resource or struct that will have a public
+capability needs to have entitled accecss, for example `access(Owner)`.
+Then, the only way to access that functionality would be through an entitled reference,
+like `<auth(Owner) &MyResource>`.
 
 ## Account Storage
 
@@ -24,19 +27,23 @@ Don't trust a users’ [account storage](https://cadence-lang.org/docs/language/
 
 Always [borrow](https://cadence-lang.org/docs/language/capabilities) with the specific type that is expected. Or, check if the value is an instance of the expected type.
 
-## Auth Accounts
+## Authorized Accounts
 
-Access to an `AuthAccount` gives full access to the account's storage, keys, and contracts. Therefore, [avoid using AuthAccount](https://cadence-lang.org/docs/1.0/anti-patterns#avoid-using-authaccount-as-a-function-parameter) as a function parameter unless absolutely necessary.
+Access to an `&Account` gives access to whatever is specified in the account entitlements
+list when that account reference is created.
+Therefore, [avoid using Account references](https://cadence-lang.org/docs/1.0/anti-patterns#avoid-using-authaccount-as-a-function-parameter) as a function parameter or field unless absolutely necessary and only use the minimal set of entitlements required
+for the specified functionality so that other account functionality cannot be accessed.
 
-It is preferable to use capabilities over direct `AuthAccount` storage when exposing account data. Using capabilities allows the revocation of access by unlinking and limits the access to a single value with a certain set of functionality – access to an `AuthAccount` gives full access to the whole storage, as well as key and contract management.
+It is preferable to use capabilities over direct `&Account` references when exposing account data. Using capabilities allows the revocation of access by unlinking and limits the access to a single value with a certain set of functionality.
 
 ## Capabilities
 
-Don’t store anything under the [public capability storage](https://cadence-lang.org/docs/language/capabilities) unless strictly required. Anyone can access your public capability using `AuthAccount.getCapability`. If something needs to be stored under `/public/`, make sure only read functionality is provided by restricting its type using either a resource interface or struct interface.
+Don’t store anything under the [public capability storage](https://cadence-lang.org/docs/language/capabilities) unless strictly required. Anyone can access your public capability using `AuthAccount.capabilities.get`. If something needs to be stored under `/public/`, make sure only read functionality is provided by restricting privileged functions with entitlements.
 
-When linking a capability, the link might already be present. In that case, Cadence will not panic with a runtime error but the link function will return `nil`.
+When publishing a capability, the capability might already be present at the given `PublicPath`.
+In that case, Cadence will panic with a runtime error to not override the already published capability.
 
-It is a good practice to check if the link already exists with `getLinkTarget` before creating it. This function will return `nil` if the link does not exist.
+It is a good practice to check if the public capability already exists with `account.capabilities.get().check` before creating it. This function will return `nil` if the capability does not exist.
 
 If it is necessary to handle the case where borrowing a capability might fail, the `account.check` function can be used to verify that the target exists and has a valid type.
 
@@ -46,7 +53,7 @@ Ensure capabilities cannot be accessed by unauthorized parties. For example, cap
 
 Audits of Cadence code should also include [transactions](https://cadence-lang.org/docs/language/transactions), as they may contain arbitrary code, just, like in contracts. In addition, they are given full access to the accounts of the transaction’s signers, i.e. the transaction is allowed to manipulate the signers’ account storage, contracts, and keys.
 
-Signing a transaction gives access to the `AuthAccount`, i.e. full access to the account’s storage, keys, and contracts.
+Signing a transaction gives access to the `&Account`, i.e. access to the account’s storage, keys, and contracts depending on what entitlements are specified.
 
 Do not blindly sign a transaction. The transaction could for example change deployed contracts by upgrading them with malicious statements, revoking or adding keys, transferring resources from storage, etc.
 
@@ -58,8 +65,8 @@ If given a less-specific type, cast to the more specific type that is expected. 
 
 ## Access Control
 
-Declaring a field as [`pub/access(all)`](https://cadence-lang.org/docs/language/access-control) only protects from replacing the field’s value, but the value itself can still be mutated if it is mutable. Remember that containers, like dictionaries, and arrays, are mutable.
+Declaring a field as [`access(all)`](https://cadence-lang.org/docs/language/access-control) only protects from replacing the field’s value, but the value itself can still be mutated if it is mutable. Remember that containers, like dictionaries, and arrays, are mutable.
 
 Prefer non-public access to a mutable state. That state may also be nested. For example, a child may still be mutated even if its parent exposes it through a field with non-settable access.
 
-Do not use the `pub/access(all)` modifier on fields and functions unless necessary. Prefer `priv/access(self)`, or `access(contract)` and `access(account)` when other types in the contract or account need to have access.
+Do not use the `access(all)` modifier on fields and functions unless necessary. Prefer `access(self)`, `acccess(Entitlement)`, or `access(contract)` and `access(account)` when other types in the contract or account need to have access.

--- a/docs/build/smart-contracts/overview.md
+++ b/docs/build/smart-contracts/overview.md
@@ -77,7 +77,7 @@ Flow has a standard contract to facilitate both the direct sales and peer-to-pee
 
 Fungible tokens (i.e. coins, currencies) on the Flow blockchain, including the default cryptocurrency token FLOW, implement the [FungibleToken](../../build/core-contracts/02-fungible-token.md) interface.
 
-See the [FT Guide](../guides/ft.md) for a guide on how to create a basic fungible token 
+See the [FT Guide](../guides/fungible-token.md) for a guide on how to create a basic fungible token 
 contract that conforms to the standard.
 
 - [Fungible Token contract interface](../../build/core-contracts/02-fungible-token.md)

--- a/docs/build/smart-contracts/overview.md
+++ b/docs/build/smart-contracts/overview.md
@@ -62,6 +62,9 @@ The Flow blockchain has existing smart contract standards for both fungible and 
 
 All NFTs on the Flow blockchain implement the [NonFungibleToken](../../build/core-contracts/08-non-fungible-token.md) interface, allowing them to be compatible with wallets, marketplaces and other cross-app experiences.
 
+See the [NFT Guide](../guides/nft.md) for a guide on how to create a basic NFT contract
+that conforms to the standard.
+
 - [Non-Fungible Token (NFT) contract interface](../../build/core-contracts/08-non-fungible-token.md)
 
 ### NFT Sales and Trading
@@ -73,5 +76,8 @@ Flow has a standard contract to facilitate both the direct sales and peer-to-pee
 ### Fungible Tokens
 
 Fungible tokens (i.e. coins, currencies) on the Flow blockchain, including the default cryptocurrency token FLOW, implement the [FungibleToken](../../build/core-contracts/02-fungible-token.md) interface.
+
+See the [FT Guide](../guides/ft.md) for a guide on how to create a basic fungible token 
+contract that conforms to the standard.
 
 - [Fungible Token contract interface](../../build/core-contracts/02-fungible-token.md)

--- a/docs/ecosystem/wallets.md
+++ b/docs/ecosystem/wallets.md
@@ -18,12 +18,6 @@ Store, manage, and interact securely with tokens and digital assets on Flow. Dis
 - https://wallet.flow.com/
 - https://frw.gitbook.io/
 
-## Blocto
-
-[Blocto](https://www.blocto.io/) is a cross-chain mobile wallet for IOS and Android devices.
-
-https://www.blocto.io/
-
 ## Dapper Wallet
 
 [Dapper Wallet](https://www.meetdapper.com/) is a wallet exceptionally friendly for first time crypto collectors to buy and manage digital assets.
@@ -67,6 +61,12 @@ https://www.finoa.io/flow/
 https://shadow.app/wallet
 
 </div>
+
+## Blocto
+
+[Blocto](https://www.blocto.io/) is a cross-chain mobile wallet for IOS and Android devices.
+
+https://www.blocto.io/
 
 ## Flow Dev Wallet
 


### PR DESCRIPTION
Making progress towards #531 

I reviewed all the docs in these directories and updated any I saw to be compatible with Cadence 1.0. After this, I am comfortable saying that they are good enough to go.

This is only having reviewed from a Cadence code perspective. There may be sdk or FCL code examples and descriptions that still need to be updated.

- `build/advanced-concepts/`
- `build/basics/`
- `build/core-contracts/`
- `build/differences-vs-evm/`
- `build/getting-started/`
- `build/guides/`
- `build/smart-contracts/`
- `ecosystem/`
- `networks/flow-networks/`
- `networks/flow-port/`

Updates to the staking and epoch documentation will come in a separate PR.