### PR TITLE
Add redirect to fix broken link in EVM

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1224,6 +1224,10 @@
     {
       "source": "/build/differences-vs-evm/transaction-time",
       "destination": "/build/basics/transactions#transaction-time"
+    },
+    {
+      "source": "/networks/flow-networks/accessing-previewnet",
+      "destination": "/evm/using"
     }
   ]
 }


### PR DESCRIPTION
Addressing "found a bug on the site,
on https://flow.com/upgrade/crescendo/evm if i click build on previewnet it leads to 404 here https://developers.flow.com/networks/flow-networks/accessing-previewnet"