### PR TITLE
Add docs about machine account metrics

### DIFF
--- a/docs/networks/node-ops/node-operation/monitoring-nodes.md
+++ b/docs/networks/node-ops/node-operation/monitoring-nodes.md
@@ -60,6 +60,37 @@ The following are some important metrics produced by the node.
 | consensus_hotstuff_cur_view           | Current view of the HotStuff consensus algorith; Consensus/Collection only; should increase at a constant rate.         |
 | consensus_hotstuff_timeout_seconds    | How long it takes to timeout failed rounds; Consensus/Collection only; values consistently larger than 5s are abnormal. |
 
+### Machine Account
+
+Collection and consensus nodes use a machine account that must be kept funded. See [here](../../staking/11-machine-account.md) for details.
+
+Nodes check their machine account's configuration and funding and produce metrics.
+
+| Metric Name                           | Description                                                                                                             |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| machine_account_balance                                | The current balance (FLOW) |
+| machine_account_recommended_min_balance                | The recommended minimum balance (FLOW) |
+| machine_account_is_misconfigured                       | 0 if the node is configured correctly; 1 if the node is misconfigured |
+
+To be notified when your node's machine account needs to be refilled or has a configuration error, you can set up alerts.
+
+When the machine account balance needs to be refilled:
+```
+machine_account_balance < machine_account_recommended_min_balance
+```
+
+When the machine account has a configuration error:
+```
+machine_account_is_misconfigured > 0
+```
+
+The metrics include the account address of the machine account for convenience:
+```
+# HELP machine_account_balance the last observed balance of this node's machine account, in units of FLOW
+# TYPE machine_account_balance gauge
+machine_account_balance{acct_address="7b16b57ae0a3c6aa"} 9.99464935
+```
+
 ## Monitoring a Flow node using Metrika Monitoring
 
 Metrika has developed the Flow node monitoring service and is the recommended way of monitoring a Flow node.

--- a/docs/networks/node-ops/node-operation/monitoring-nodes.md
+++ b/docs/networks/node-ops/node-operation/monitoring-nodes.md
@@ -84,7 +84,7 @@ When the machine account has a configuration error:
 machine_account_is_misconfigured > 0
 ```
 
-The metrics include the account address of the machine account for convenience:
+The metrics include the account address of the machine account (`acct_address` label) for convenience:
 ```
 # HELP machine_account_balance the last observed balance of this node's machine account, in units of FLOW
 # TYPE machine_account_balance gauge

--- a/docs/networks/staking/11-machine-account.md
+++ b/docs/networks/staking/11-machine-account.md
@@ -34,7 +34,7 @@ however more may be required under certain circumstances and network conditions.
 <Callout type="info">
 
 Because some transactions sent by the Machine Account are system critical, we recommend maintaining
-a balance sufficient to accommodate worst-case transaction submission numbers at all times. See []
+a balance sufficient to accommodate worst-case transaction submission numbers at all times. See [here](./../node-ops/node-operation/monitoring-nodes.md) for how to monitor.
 
 </Callout>
 

--- a/docs/networks/staking/11-machine-account.md
+++ b/docs/networks/staking/11-machine-account.md
@@ -34,7 +34,7 @@ however more may be required under certain circumstances and network conditions.
 <Callout type="info">
 
 Because some transactions sent by the Machine Account are system critical, we recommend maintaining
-a balance sufficient to accommodate worst-case transaction submission numbers at all times.
+a balance sufficient to accommodate worst-case transaction submission numbers at all times. See []
 
 </Callout>
 

--- a/docs/networks/staking/11-machine-account.md
+++ b/docs/networks/staking/11-machine-account.md
@@ -34,7 +34,7 @@ however more may be required under certain circumstances and network conditions.
 <Callout type="info">
 
 Because some transactions sent by the Machine Account are system critical, we recommend maintaining
-a balance sufficient to accommodate worst-case transaction submission numbers at all times. See [here](./../node-ops/node-operation/monitoring-nodes.md) for how to monitor.
+a balance sufficient to accommodate worst-case transaction submission numbers at all times. **See [here](./../node-ops/node-operation/monitoring-nodes.md#machine-account) for how to monitor.**
 
 </Callout>
 


### PR DESCRIPTION
Mainnet25 includes new metrics for monitoring machine account balances. This PR updates the documentation to add examples for how to monitor and alert on these metrics. 