### PR TITLE
Update Borrow function in NFT Docs

### DIFF
--- a/docs/build/guides/nft.md
+++ b/docs/build/guides/nft.md
@@ -530,7 +530,7 @@ access(all) contract FooBar: NonFungibleToken {
         /// Allows a caller to borrow a reference to a specific NFT
         /// so that they can get the metadata views for the specific NFT
         access(all) view fun borrowNFT(_ id: UInt64): &{NonFungibleToken.NFT}? {
-            return (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
+            return &self.ownedNFTs[id]
         }
 
         // ...[rest of code]...

--- a/docs/build/guides/nft.md
+++ b/docs/build/guides/nft.md
@@ -530,7 +530,7 @@ access(all) contract FooBar: NonFungibleToken {
         /// Allows a caller to borrow a reference to a specific NFT
         /// so that they can get the metadata views for the specific NFT
         access(all) view fun borrowNFT(_ id: UInt64): &{NonFungibleToken.NFT}? {
-            return (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)
+            return (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
         }
 
         // ...[rest of code]...


### PR DESCRIPTION
In the Collection resource borrowNFT_  function gives an error.
NonFungibleToken type cast to `&{NFT}?` is redundant. 

Solution: To remove this error add Force Unwrap Operator (!).