### PR TITLE
Update the rest of non-account linking docs to Cadence 1.0

### DIFF
--- a/docs/build/advanced-concepts/metadata-views.md
+++ b/docs/build/advanced-concepts/metadata-views.md
@@ -308,7 +308,7 @@ Each royalty view contains a fungible token receiver capability where royalties 
 ```cadence
 access(all) struct Royalty {
 
-    access(all) let receiver: Capability<&AnyResource{FungibleToken.Receiver}>
+    access(all) let receiver: Capability<&{FungibleToken.Receiver}>
 
     access(all) let cut: UFix64
 }
@@ -337,7 +337,8 @@ accepts the seller's desired fungible token by calling
 the `receiver.getSupportedVaultTypes(): {Type: Bool}`
 function via the `receiver` reference:
 ```cadence
-let royaltyReceiverRef = royalty.receiver.borrow() ?? panic("Could not borrow a reference to the receiver")
+let royaltyReceiverRef = royalty.receiver.borrow()
+    ?? panic("Could not borrow a reference to the receiver")
 let supportedTypes = receiverRef.getSupportedVaultTypes() 
 if supportedTypes[**royalty.getType()**] {
     // The type is supported, so you can deposit
@@ -477,8 +478,8 @@ case Type<MetadataViews.NFTCollectionData>():
         // where to borrow public capabilities from?
         publicPath: ExampleNFT.CollectionPublicPath,
         // Important types for how the collection should be linked
-        publicCollection: Type<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic}>(),
-        publicLinkedType: Type<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Receiver,MetadataViews.ResolverCollection}>(),
+        publicCollection: Type<&ExampleNFT.Collection>(),
+        publicLinkedType: Type<&ExampleNFT.Collection>(),
         // function that can be accessed to create an empty collection for the project
         createEmptyCollectionFunction: (fun(): @{NonFungibleToken.Collection} {
             return <-ExampleNFT.createEmptyCollection(nftType: Type<@ExampleNFT.NFT>())

--- a/docs/build/basics/transactions.md
+++ b/docs/build/basics/transactions.md
@@ -25,7 +25,7 @@ The script section contains instructions for transaction execution. This is a Ca
 
 A transaction includes multiple optional phases `prepare`, `pre`, `execute`, and `post` phase. You can read more about it in the [Cadence reference document on transactions](https://cadence-lang.org/docs/language/transactions). Each phase has a purpose, the two most important phases are `prepare` and `execute`. 
 
-In the `prepare` phase, we have access to `AuthAccount` objects, which gives us the power to interact with those accounts. The accounts are called authorizers of transactions, so each account we want to interact with in the `prepare` phase must sign the transaction as an authorizer. 
+In the `prepare` phase, we have access to `&Account` objects, which gives us the power to interact with those accounts. The accounts are called authorizers of transactions, so each account we want to interact with in the `prepare` phase must sign the transaction as an authorizer. 
 The `execute` phase does exactly what it says, it executes the main logic of the transaction. This phase is optional, but it is a best practice to add your main transaction logic in the section, so it is explicit. 
 
 Again make sure to read Cadence [documentation on transactions](https://cadence-lang.org/docs/language/transactions)
@@ -70,7 +70,7 @@ A proposal key definition declares the address, key ID, and up-to-date sequence 
 
 Authorizers are accounts that authorize a transaction to read and mutate their state. A transaction can specify zero or more authorizers, depending on how many accounts the transaction needs to access.
 
-The number of authorizers on the transaction must match the number of AuthAccount parameters declared in the prepare statement of the Cadence script.
+The number of authorizers on the transaction must match the number of &Account parameters declared in the prepare statement of the Cadence script.
 
 Example transaction with multiple authorizers:
 

--- a/docs/build/core-contracts/10-nft-storefront.md
+++ b/docs/build/core-contracts/10-nft-storefront.md
@@ -131,11 +131,15 @@ Providing that a seller's NFT supports the [Royalty Metadata View](https://githu
 ```cadence
 // Check whether the NFT implements the MetadataResolver or not.
 if nft.getViews().contains(Type<MetadataViews.Royalties>()) {
-		// Resolve the royalty view
-    let royaltiesRef = nft.resolveView(Type<MetadataViews.Royalties>())?? panic("Unable to retrieve the royalties")
-	  // Fetch the royalties.
-		let royalties = (royaltiesRef as! MetadataViews.Royalties).getRoyalties()
-		// Append the royalties as the salecut
+	// Resolve the royalty view
+    let royaltiesRef = nft.resolveView(Type<MetadataViews.Royalties>())
+        ?? panic("Unable to retrieve the royalties view for the NFT with type "
+           .concat(nft.getType().identifier).concat(" and ID ")
+           .concat(nft.id.toString()).concat(".")
+	// Fetch the royalties.
+	let royalties = (royaltiesRef as! MetadataViews.Royalties).getRoyalties()
+
+	// Append the royalties as the salecut
     for royalty in royalties {
         self.saleCuts.append(NFTStorefrontV2.SaleCut(receiver: royalty.receiver, amount: royalty.cut * effectiveSaleItemPrice))
         totalRoyaltyCut = totalRoyaltyCut + royalty.cut * effectiveSaleItemPrice
@@ -316,7 +320,7 @@ Cleanup the expired listing by iterating over the provided range of indexes.
 **fun `borrowListing()`**
 
 ```cadence
-fun borrowListing(listingResourceID UInt64): &Listing{ListingPublic}?
+fun borrowListing(listingResourceID: UInt64): &{ListingPublic}?
 ```
 
 borrowListing

--- a/docs/build/core-contracts/14-burner.md
+++ b/docs/build/core-contracts/14-burner.md
@@ -6,7 +6,7 @@ sidebar_label: Burner
 
 # Contract
 
-The [Burner]() contract provides a way for resources to define
+The [Burner](https://github.com/onflow/flow-ft/blob/master/contracts/utility/Burner.cdc) contract provides a way for resources to define
 custom logic that is executed when the resource is destroyed.
 Resources that want to utilize this functionality should implement
 the `Burner.Burnable` interface which requires that they include

--- a/docs/build/core-contracts/14-burner.md
+++ b/docs/build/core-contracts/14-burner.md
@@ -1,0 +1,23 @@
+---
+title: Flow Burner Contract Address
+sidebar_position: 14
+sidebar_label: Burner
+---
+
+# Contract
+
+The [Burner]() contract provides a way for resources to define
+custom logic that is executed when the resource is destroyed.
+Resources that want to utilize this functionality should implement
+the `Burner.Burnable` interface which requires that they include
+a `burnCallback()` function that includes the custom logic.
+
+It is recommended that regardless of the resource, all users and developers
+should use `Burner.burn()` when destroying a resource instead of `destroy`.
+
+| Network | Contract Address                                                               |
+| ------- | ------------------------------------------------------------------------------ |
+| Cadence Testing Framework | `0x0000000000000001` |
+| Emulator | `0xee82856bf20e2aa6` |
+| Testnet | [`0x294e44e1ec6993c6`](https://contractbrowser.com/account/0x294e44e1ec6993c6) |
+| Mainnet | [`0xd8a7e05a7ac670c0`](https://contractbrowser.com/account/0xd8a7e05a7ac670c0) |

--- a/docs/build/differences-vs-evm/index.md
+++ b/docs/build/differences-vs-evm/index.md
@@ -68,7 +68,7 @@ import ExampleNFT from 0x2bd9d8989a3352a1
 transaction(recipient: Address) {
 
     /// Reference to the receiver's collection
-    let recipientCollectionRef: &{NonFungibleToken.CollectionPublic}
+    let recipientCollectionRef: &{NonFungibleToken.Collection}
 
     /// Previous NFT ID before the transaction executes
     let mintingIDBefore: UInt64
@@ -79,9 +79,12 @@ transaction(recipient: Address) {
 
         // Borrow the recipient's public NFT collection reference
         self.recipientCollectionRef = getAccount(recipient)
-            .capabilities.get<&{NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)
+            .capabilities.get<&{NonFungibleToken.Collection}>(ExampleNFT.CollectionPublicPath)
             .borrow()
-            ?? panic("Could not get receiver reference to the NFT Collection")
+            ?? panic("The recipient does not have a NonFungibleToken Receiver at "
+                    .concat(ExampleNFT.CollectionPublicPath.toString())
+                    .concat(" that is capable of receiving an NFT.")
+                    .concat("The recipient must initialize their account with this collection and receiver first!"))
 
     }
 
@@ -127,9 +130,13 @@ access(all) fun main(address: Address, collectionPublicPath: PublicPath): [UInt6
     let account = getAccount(address)
 
     let collectionRef = account
-        .capabilities.get<&{NonFungibleToken.CollectionPublic}>(collectionPublicPath)
+        .capabilities.get<&{NonFungibleToken.Collection}>(collectionPublicPath)
         .borrow()
-        ?? panic("Could not borrow capability from public collection at specified path")
+            ?? panic("The account with address "
+                    .concat(address.toString())
+                    .concat("does not have a NonFungibleToken Collection at "
+                    .concat(ExampleNFT.CollectionPublicPath.toString())
+                    .concat(". The account must initialize their account with this collection first!")))
 
     return collectionRef.getIDs()
 

--- a/docs/build/getting-started/quickstarts/flow-cli.md
+++ b/docs/build/getting-started/quickstarts/flow-cli.md
@@ -106,8 +106,7 @@ This will create a file called `ReadGreeting.cdc` in the `cadence/scripts` direc
 ```
 import "HelloWorld"
 
-access(all)
-fun main(): String {
+access(all) fun main(): String {
   return HelloWorld.greeting
 }
 ```
@@ -141,7 +140,7 @@ import "HelloWorld"
 
 transaction(greeting: String) {
 
-  prepare(acct: AuthAccount) {
+  prepare(acct: &Account) {
     log(acct.address)
   }
 

--- a/docs/build/guides/mobile/react-native-quickstart.md
+++ b/docs/build/guides/mobile/react-native-quickstart.md
@@ -533,7 +533,7 @@ export default function App() {
             // Only initialize the account if it hasn't already been initialized
             if (!Profile.check(account.address)) {
               // This creates and stores the profile in the user's account
-              account.save(<- Profile.new(), to: Profile.privatePath)
+              account.storage.save(<- Profile.new(), to: Profile.storagePath)
   
               // This creates the public capability that lets applications read the profile's info
               let newCap = account.capabilities.storage.issue<&Profile.Base>(Profile.privatePath)
@@ -561,7 +561,7 @@ export default function App() {
   
         transaction(name: String) {
           prepare(account: auth(BorrowValue) &Account) {
-            let profileRef = account.borrow<&Profile.Base>(from: Profile.privatePath)
+            let profileRef = account.storage.borrow<&Profile.Base>(from: Profile.privatePath)
                 ?? panic("The signer does not store a Profile.Base object at the path "
                         .concat(Profile.privatePath.toString())
                         .concat(". The signer must initialize their account with this object first!"))

--- a/docs/ecosystem/wallets.md
+++ b/docs/ecosystem/wallets.md
@@ -54,14 +54,6 @@ https://niftory.com/
 
 https://www.finoa.io/flow/
 
-## Shadow
-
-[Shadow](https://shadow.app/wallet) is your web3 companion, enabling you to store your assets, transact with friends, and connect to apps on multiple chains.
-
-https://shadow.app/wallet
-
-</div>
-
 ## Blocto
 
 [Blocto](https://www.blocto.io/) is a cross-chain mobile wallet for IOS and Android devices.

--- a/docs/ecosystem/wallets.md
+++ b/docs/ecosystem/wallets.md
@@ -54,6 +54,8 @@ https://niftory.com/
 
 https://www.finoa.io/flow/
 
+</div>
+
 ## Blocto
 
 [Blocto](https://www.blocto.io/) is a cross-chain mobile wallet for IOS and Android devices.

--- a/docs/evm/cadence/direct-calls.md
+++ b/docs/evm/cadence/direct-calls.md
@@ -60,7 +60,7 @@ import EVM from <ServiceAddress>
 
 transaction(rlpEncodedTransaction: [UInt8], coinbaseBytes: [UInt8; 20]) {
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: &Account) {
         let coinbase = EVM.EVMAddress(bytes: coinbaseBytes)
         let result = EVM.run(tx: rlpEncodedTransaction, coinbase: coinbase)
         assert(

--- a/docs/tooling/wallet-provider-spec/authorization-function.md
+++ b/docs/tooling/wallet-provider-spec/authorization-function.md
@@ -19,7 +19,7 @@ import * as fcl from "@onflow/fcl"
 const myAuthorizationFunction = ... // An Authorization Function
 
 const response = fcl.send([
-    fcl.transaction`transaction() { prepare(acct: AuthAccount) {} execute { log("Hello, Flow!") } }`,
+    fcl.transaction`transaction() { prepare(acct: &Account) {} execute { log("Hello, Flow!") } }`,
     fcl.proposer(myAuthorizationFunction),
     fcl.payer(myAuthorizationFunction),
     fcl.authorizers([ myAuthorizationFunction ])

--- a/docs/tools/clients/fcl-js/api.md
+++ b/docs/tools/clients/fcl-js/api.md
@@ -296,8 +296,8 @@ const txId = await fcl.mutate({
     import Profile from 0xba1132bc08f82fe2
     
     transaction(name: String) {
-      prepare(account: AuthAccount) {
-        account.borrow<&{Profile.Owner}>(from: Profile.privatePath)!.setName(name)
+      prepare(account: auth(BorrowValue) &Account) {
+        account.storage.borrow<&{Profile.Owner}>(from: Profile.privatePath)!.setName(name)
       }
     }
   `,
@@ -611,8 +611,8 @@ const txId = await fcl.mutate({
     import Profile from 0xba1132bc08f82fe2
     
     transaction(name: String) {
-      prepare(account: AuthAccount) {
-        account.borrow<&{Profile.Owner}>(from: Profile.privatePath)!.setName(name)
+      prepare(account: auth(BorrowValue) &Account) {
+        account.storage.borrow<&{Profile.Owner}>(from: Profile.privatePath)!.setName(name)
       }
     }
   `,

--- a/docs/tools/clients/fcl-js/index.md
+++ b/docs/tools/clients/fcl-js/index.md
@@ -91,8 +91,8 @@ const txId = await fcl.mutate({
     import Profile from 0xba1132bc08f82fe2
     
     transaction(name: String) {
-      prepare(account: AuthAccount) {
-        account.borrow<&{Profile.Owner}>(from: Profile.privatePath)!.setName(name)
+      prepare(account: auth(BorrowValue) &Account) {
+        account.storage.borrow<&{Profile.Owner}>(from: Profile.privatePath)!.setName(name)
       }
     }
   `,

--- a/docs/tools/clients/fcl-js/index.mdx.txt
+++ b/docs/tools/clients/fcl-js/index.mdx.txt
@@ -105,8 +105,8 @@ const txId = await fcl.mutate({
     import Profile from 0xba1132bc08f82fe2
     
     transaction(name: String) {
-      prepare(account: AuthAccount) {
-        account.borrow<&{Profile.Owner}>(from: Profile.privatePath)!.setName(name)
+      prepare(account: auth(BorrowValue) &Account) {
+        account.storage.borrow<&{Profile.Owner}>(from: Profile.privatePath)!.setName(name)
       }
     }
   `,

--- a/docs/tools/clients/fcl-js/interaction-templates.mdx
+++ b/docs/tools/clients/fcl-js/interaction-templates.mdx
@@ -216,7 +216,7 @@ The following is an example Interaction Template that corresponds to a "Transfer
         }
       }
     },
-    "cadence": "import FungibleToken from 0xFUNGIBLETOKENADDRESS\ntransaction(amount: UFix64, to: Address) {\nlet vault: @FungibleToken.Vault\nprepare(signer: AuthAccount) {\nself.vault <- signer\n.borrow<&{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n.withdraw(amount: amount)\n}\nexecute {\ngetAccount(to)\n.getCapability(/public/flowTokenReceiver)!\n.borrow<&{FungibleToken.Receiver}>()!\n.deposit(from: <-self.vault)\n}\n}",
+    "cadence": "import FungibleToken from 0xFUNGIBLETOKENADDRESS\ntransaction(amount: UFix64, to: Address) {\nlet vault: @FungibleToken.Vault\nprepare(signer: &Account) {\nself.vault <- signer\n.borrow<&{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n.withdraw(amount: amount)\n}\nexecute {\ngetAccount(to)\n.getCapability(/public/flowTokenReceiver)!\n.borrow<&{FungibleToken.Receiver}>()!\n.deposit(from: <-self.vault)\n}\n}",
     "dependencies": {
       "0xFUNGIBLETOKENADDRESS": {
         "FungibleToken": {

--- a/docs/tools/clients/fcl-js/interaction-templates.mdx
+++ b/docs/tools/clients/fcl-js/interaction-templates.mdx
@@ -216,7 +216,7 @@ The following is an example Interaction Template that corresponds to a "Transfer
         }
       }
     },
-    "cadence": "import FungibleToken from 0xFUNGIBLETOKENADDRESS\ntransaction(amount: UFix64, to: Address) {\nlet vault: @FungibleToken.Vault\nprepare(signer: &Account) {\nself.vault <- signer\n.borrow<&{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n.withdraw(amount: amount)\n}\nexecute {\ngetAccount(to)\n.getCapability(/public/flowTokenReceiver)!\n.borrow<&{FungibleToken.Receiver}>()!\n.deposit(from: <-self.vault)\n}\n}",
+    "cadence": "import FungibleToken from 0xFUNGIBLETOKENADDRESS\ntransaction(amount: UFix64, to: Address) {\nlet vault: @FungibleToken.Vault\nprepare(signer: &Account) {\nself.vault <- signer\n.borrow<&{FungibleToken.Provider}>(from: /storage/flowTokenVault)!\n.withdraw(amount: amount)\n}\nexecute {\ngetAccount(to)\n.capabilities.get(/public/flowTokenReceiver)!\n.borrow<&{FungibleToken.Receiver}>()!\n.deposit(from: <-self.vault)\n}\n}",
     "dependencies": {
       "0xFUNGIBLETOKENADDRESS": {
         "FungibleToken": {

--- a/docs/tools/clients/fcl-js/sdk-guidelines.md
+++ b/docs/tools/clients/fcl-js/sdk-guidelines.md
@@ -305,12 +305,12 @@ A transaction is only valid if its declared sequence number matches the current 
 
 📖 **[Authorizers](../../../build/basics/transactions.md#signer-roles)** are accounts that authorize a transaction to read and mutate their resources. A transaction can specify zero or more authorizers, depending on how many accounts the transaction needs to access.
 
-The number of authorizers on the transaction must match the number of AuthAccount parameters declared in the prepare statement of the Cadence script.
+The number of authorizers on the transaction must match the number of `&Account` parameters declared in the prepare statement of the Cadence script.
 
 Example transaction with multiple authorizers:
 ```
 transaction {
-  prepare(authorizer1: AuthAccount, authorizer2: AuthAccount) { }
+  prepare(authorizer1: &Account, authorizer2: &Account) { }
 }
 ```
 
@@ -334,7 +334,7 @@ import * as fcl from "@onflow/fcl"
 await fcl.mutate({
   cadence: `
     transaction(a: Int) {
-      prepare(acct: AuthAccount) {
+      prepare(acct: &Account) {
         log(acct)
         log(a)
       }
@@ -367,7 +367,7 @@ import * as fcl from "@onflow/fcl"
 await fcl.mutate({
   cadence: `
     transaction {
-      prepare(acct: AuthAccount) {}
+      prepare(acct: &Account) {}
     }
   `,
   proposer: currentUser,
@@ -381,7 +381,7 @@ await fcl.mutate({
 mutate({
   cadence: `
     transaction {
-      prepare(acct: AuthAccount) {}
+      prepare(acct: &Account) {}
     }
   `,
   authz: currentUser, // Optional. Will default to currentUser if not provided.
@@ -408,7 +408,7 @@ const authzFn = async (txAccount) => {
 mutate({
   cadence: `
     transaction {
-      prepare(acct: AuthAccount) {}
+      prepare(acct: &Account) {}
     }
   `,
   proposer: authzFn,
@@ -465,7 +465,7 @@ const authzFn = async (txAccount) => {
 mutate({
   cadence: `
     transaction {
-      prepare(acct: AuthAccount) {}
+      prepare(acct: &Account) {}
     }
   `,
   proposer: authzFn,
@@ -525,7 +525,7 @@ const authzTwoFn = async (txAccount) => {
 mutate({
   cadence: `
     transaction {
-      prepare(acct: AuthAccount) {}
+      prepare(acct: &Account) {}
     }
   `,
   proposer: authzFn,
@@ -542,7 +542,7 @@ mutate({
 - Account `0x01` signs the payload.
 - Account `0x02` signs the envelope.
     - Account `0x02` must sign last since it is the payer.
-- Account `0x02` is also an authorizer to show how to include two AuthAccounts into an transaction
+- Account `0x02` is also an authorizer to show how to include two `&Account` objects into an transaction
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
@@ -586,7 +586,7 @@ const authzTwoFn = async (txAccount) => {
 mutate({
   cadence: `
     transaction {
-      prepare(acct: AuthAccount, acct2: AuthAccount) {}
+      prepare(acct: &Account, acct2: &Account) {}
     }
   `,
   proposer: authzFn,
@@ -676,7 +676,7 @@ const authzTwoFn = async (txAccount) => {
 mutate({
   cadence: `
     transaction {
-      prepare(acct: AuthAccount) {}
+      prepare(acct: &Account) {}
     }
   `,
   proposer: authzFn,

--- a/docs/tools/clients/fcl-js/transactions.md
+++ b/docs/tools/clients/fcl-js/transactions.md
@@ -46,7 +46,7 @@ The below code snippet is the same as the above one, except for one extremely im
 Our Cadence code this time has a prepare statement, and we are using the `fcl.currentUser` when constructing our transaction.
 
 The `prepare` statement's arguments directly map to the order of the authorizations in the `authorizations` array.
-Four authorizations means four `AuthAccount`s as arguments passed to `prepare`. In this case though there is only one, and it is the `currentUser`.
+Four authorizations means four `&Account`s as arguments passed to `prepare`. In this case though there is only one, and it is the `currentUser`.
 
 These authorizations are important as you can only access/modify an accounts storage if you have the said accounts authorization.
 
@@ -56,7 +56,7 @@ import * as fcl from "@onflow/fcl"
 const transactionId = await fcl.mutate({
   cadence: `
     transaction {
-      prepare(acct: AuthAccount) {
+      prepare(acct: &Account) {
         log("Hello from prepare")
       }
       execute {

--- a/docs/tools/clients/flow-go-sdk/index.mdx
+++ b/docs/tools/clients/flow-go-sdk/index.mdx
@@ -538,13 +538,13 @@ A transaction is only valid if its declared sequence number matches the current 
 
 📖 **[Authorizers](../../../build/basics/transactions.md#signer-roles)** are accounts that authorize a transaction to read and mutate their resources. A transaction can specify zero or more authorizers, depending on how many accounts the transaction needs to access.
 
-The number of authorizers on the transaction must match the number of AuthAccount parameters declared in the prepare statement of the Cadence script.
+The number of authorizers on the transaction must match the number of &Account parameters declared in the prepare statement of the Cadence script.
 
 Example transaction with multiple authorizers:
 
 ```
 transaction {
-  prepare(authorizer1: AuthAccount, authorizer2: AuthAccount) { }
+  prepare(authorizer1: &Account, authorizer2: &Account) { }
 }
 ```
 
@@ -570,7 +570,7 @@ transaction(greeting: String) {
 
   let guest: Address
 
-  prepare(authorizer: AuthAccount) {
+  prepare(authorizer: &Account) {
     self.guest = authorizer.address
   }
 
@@ -719,7 +719,7 @@ referenceBlock, _ := flow.GetLatestBlock(ctx, true)
 tx := flow.NewTransaction().
     SetScript([]byte(`
         transaction {
-            prepare(signer: AuthAccount) { log(signer.address) }
+            prepare(signer: &Account) { log(signer.address) }
         }
     `)).
     SetComputeLimit(100).
@@ -759,7 +759,7 @@ referenceBlock, _ := flow.GetLatestBlock(ctx, true)
 tx := flow.NewTransaction().
     SetScript([]byte(`
         transaction {
-            prepare(signer: AuthAccount) { log(signer.address) }
+            prepare(signer: &Account) { log(signer.address) }
         }
     `)).
     SetComputeLimit(100).
@@ -805,7 +805,7 @@ referenceBlock, _ := flow.GetLatestBlock(ctx, true)
 tx := flow.NewTransaction().
     SetScript([]byte(`
         transaction {
-            prepare(signer: AuthAccount) { log(signer.address) }
+            prepare(signer: &Account) { log(signer.address) }
         }
     `)).
     SetComputeLimit(100).
@@ -829,7 +829,7 @@ err = tx.SignEnvelope(account2.Address, key3.Index, key3Signer)
 - Account `0x01` signs the payload.
 - Account `0x02` signs the envelope.
   - Account `0x02` must sign last since it is the payer.
-- Account `0x02` is also an authorizer to show how to include two AuthAccounts into an transaction
+- Account `0x02` is also an authorizer to show how to include two `&Account` objects into an transaction
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
@@ -853,7 +853,7 @@ referenceBlock, _ := flow.GetLatestBlock(ctx, true)
 tx := flow.NewTransaction().
     SetScript([]byte(`
         transaction {
-            prepare(signer1: AuthAccount, signer2: AuthAccount) {
+            prepare(signer1: &Account, signer2: &Account) {
               log(signer.address)
               log(signer2.address)
           }
@@ -911,7 +911,7 @@ referenceBlock, _ := flow.GetLatestBlock(ctx, true)
 tx := flow.NewTransaction().
     SetScript([]byte(`
         transaction {
-            prepare(signer: AuthAccount) { log(signer.address) }
+            prepare(signer: &Account) { log(signer.address) }
         }
     `)).
     SetComputeLimit(100).
@@ -1087,26 +1087,41 @@ to a recipient.
 _Note: this transaction is only compatible with Flow Mainnet._
 
 ```cadence
-import FungibleToken from 0xf233dcee88fe0abe
-import FlowToken from 0x1654653399040a61
+// This transaction is a template for a transaction that
+// could be used by anyone to send tokens to another account
+// that has been set up to receive tokens.
+//
+// The withdraw amount and the account from getAccount
+// would be the parameters to the transaction
 
-transaction(amount: UFix64, recipient: Address) {
-  let sentVault: @FungibleToken.Vault
-  prepare(signer: AuthAccount) {
-    let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
-      ?? panic("failed to borrow reference to sender vault")
+import "FungibleToken"
+import "FlowToken"
 
-    self.sentVault <- vaultRef.withdraw(amount: amount)
-  }
+transaction(amount: UFix64, to: Address) {
 
-  execute {
-    let receiverRef =  getAccount(recipient)
-      .getCapability(/public/flowTokenReceiver)
-      .borrow<&{FungibleToken.Receiver}>()
-        ?? panic("failed to borrow reference to recipient vault")
+    // The Vault resource that holds the tokens that are being transferred
+    let sentVault: @{FungibleToken.Vault}
 
-    receiverRef.deposit(from: <-self.sentVault)
-  }
+    prepare(signer: auth(BorrowValue) &Account) {
+
+        // Get a reference to the signer's stored vault
+        let vaultRef = signer.storage.borrow<auth(FungibleToken.Withdraw) &FlowToken.Vault>(from: /storage/flowTokenVault)
+			?? panic("Could not borrow reference to the owner's Vault!")
+
+        // Withdraw tokens from the signer's stored vault
+        self.sentVault <- vaultRef.withdraw(amount: amount)
+    }
+
+    execute {
+
+        // Get a reference to the recipient's Receiver
+        let receiverRef =  getAccount(to)
+            .capabilities.borrow<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
+			?? panic("Could not borrow receiver reference to the recipient's Vault")
+
+        // Deposit the withdrawn tokens in the recipient's receiver
+        receiverRef.deposit(from: <-self.sentVault)
+    }
 }
 ```
 

--- a/docs/tools/clients/unity-sdk/samples/nft-browser.md
+++ b/docs/tools/clients/unity-sdk/samples/nft-browser.md
@@ -23,9 +23,9 @@ First we need to get a list of all collections on an account that are a subtype 
 import NonFungibleToken from 0x1d7e57aa55817448
 
 access(all) fun main(addr: Address) : [StoragePath] {
-    //Get the AuthAccount for the given address.
-    //The AuthAccount is needed because we're going to be looking into the Storage of the user
-    var acct = getAuthAccount(addr)
+    // Get the authorized Account object for the given address.
+    // The authorized account is needed because we're going to be looking into the Storage of the user
+    var acct = getAuthAccount<auth(Storage) &Account>(addr)
     
     //Array that we will fill with all valid storage paths
     var paths : [StoragePath] = []
@@ -57,9 +57,9 @@ We use this to create a list of collection paths a user can pick from.  When the
 import NonFungibleToken from 0x1d7e57aa55817448
 
 access(all) fun main(addr: Address, path: StoragePath) : [UInt64] {
-    //Get the AuthAccount for the given address.
-    //The AuthAccount is needed because we're going to be looking into the Storage of the user
-    var acct = getAuthAccount(addr)
+    // Get the authorized Account object for the given address.
+    // The authorized account is needed because we're going to be looking into the Storage of the user
+    var acct = getAuthAccount<auth(Storage) &Account>(addr)
     
     //Get a reference to an interface of type NonFungibleToken.Collection public backed by the resource located at path
     var ref = acct.borrow<&{NonFungibleToken.CollectionPublic}>(from: path)!
@@ -82,8 +82,9 @@ access(all) fun main(addr: Address, path: StoragePath, ids: [UInt64]) : {UInt64:
     //We use AnyStruct? because that is the type that is returned by resolveView.
     var returnData: {UInt64:AnyStruct?} = {}
 
-    //Get account for address
-    var acct = getAuthAccount(addr)
+    // Get the authorized Account object for the given address.
+    // The authorized account is needed because we're going to be looking into the Storage of the user
+    var acct = getAuthAccount<auth(Storage) &Account>(addr)
     
     //Get a reference to a capability to the storage path as a NonFungibleToken.CollectionPublic
     var ref = acct.borrow<&{NonFungibleToken.CollectionPublic}>(from: path)!
@@ -185,8 +186,9 @@ access(all) struct NFTData {
 }
 
 access(all) fun main(addr: Address, path: StoragePath, id: UInt64) : NFTData? {
-    //Get account for address
-    var acct = getAuthAccount(addr)
+    // Get the authorized Account object for the given address.
+    // The authorized account is needed because we're going to be looking into the Storage of the user
+    var acct = getAuthAccount<auth(Storage) &Account>(addr)
     
     //Get a reference to a capability to the storage path as a NonFungibleToken.CollectionPublic
     var ref = acct.borrow<&{NonFungibleToken.CollectionPublic}>(from: path)!

--- a/docs/tools/clients/unity-sdk/samples/nft-example.md
+++ b/docs/tools/clients/unity-sdk/samples/nft-example.md
@@ -385,7 +385,7 @@ access(all) fun main(addr:Address): {UInt64:{String:String}} {
 
     //Get a capability to the SDKExampleNFT collection if it exists.  Return an empty dictionary if it does not
     let collectionCap = getAccount(addr).capabilities.get<&{SDKExampleNFT.CollectionPublic}>(SDKExampleNFT.CollectionPublicPath)
-    if(collectionCap == nil)
+    if(!collectionCap.check())
     {
         return {}
     }

--- a/docs/tools/clients/unity-sdk/samples/quickstart.md
+++ b/docs/tools/clients/unity-sdk/samples/quickstart.md
@@ -312,7 +312,7 @@ First we'll write the transaction we want to execute.
 string transaction = @"
     import HelloWorld from %USERADDRESS% 
     transaction {
-        prepare(acct: AuthAccount) {
+        prepare(acct: &Account) {
             log(""Transaction Test"")
             HelloWorld.hello(data:""Test Event"")
         }

--- a/docs/tools/flow-cli/flix.md
+++ b/docs/tools/flow-cli/flix.md
@@ -119,7 +119,7 @@ import "HelloWorld"
 
 transaction(greeting: String) {
 
-  prepare(acct: AuthAccount) {
+  prepare(acct: &Account) {
     log(acct.address)
   }
 

--- a/docs/tools/flow-cli/transactions/build-transactions.md
+++ b/docs/tools/flow-cli/transactions/build-transactions.md
@@ -51,7 +51,7 @@ Code
 transaction(greeting: String) {
   let guest: Address
 
-  prepare(authorizer: AuthAccount) {
+  prepare(authorizer: &Account) {
     self.guest = authorizer.address
   }
 

--- a/docs/tools/flow-cli/transactions/complex-transactions.md
+++ b/docs/tools/flow-cli/transactions/complex-transactions.md
@@ -48,7 +48,7 @@ Submit the signed transaction:
 Transaction content (`tx.cdc`):
 ```
 transaction {
-    prepare(signer: AuthAccount) {}
+    prepare(signer: &Account) {}
     execute { ... }
 }
 ```
@@ -86,7 +86,7 @@ Submit the signed transaction:
 Transaction content (`tx.cdc`):
 ```
 transaction {
-    prepare(bob: AuthAccount, charlie: AuthAccount) {}
+    prepare(bob: &Account, charlie: &Account) {}
     execute { ... }
 }
 ```
@@ -125,7 +125,7 @@ Submit the signed transaction:
 Transaction content (`tx.cdc`):
 ```
 transaction {
-    prepare(charlie: AuthAccount) {}
+    prepare(charlie: &Account) {}
     execute { ... }
 }
 ```
@@ -159,7 +159,7 @@ Submit the signed transaction:
 Transaction content (`tx.cdc`):
 ```
 transaction {
-    prepare(signer: AuthAccount) {}
+    prepare(signer: &Account) {}
     execute { ... }
 }
 ```

--- a/docs/tools/flow-cli/transactions/send-transactions.md
+++ b/docs/tools/flow-cli/transactions/send-transactions.md
@@ -46,7 +46,7 @@ Multiple arguments example:
 Transaction code:
 ```
 transaction(a: String, b: Int, c: UInt16, d: UFix64, e: Address, f: [Int], g: [String]) {
-	prepare(authorizer: AuthAccount) {}
+	prepare(authorizer: &Account) {}
 }
 ```
 

--- a/docs/tools/flow-cli/transactions/sign-transaction.md
+++ b/docs/tools/flow-cli/transactions/sign-transaction.md
@@ -48,7 +48,7 @@ Code
 transaction(greeting: String) {
   let guest: Address
 
-  prepare(authorizer: AuthAccount) {
+  prepare(authorizer: &Account) {
     self.guest = authorizer.address
   }
 

--- a/docs/tools/flow-dev-wallet/index.md
+++ b/docs/tools/flow-dev-wallet/index.md
@@ -203,7 +203,7 @@ access(all) fun main(address: Address): UFix64 {
    .capabilities.get
    <&LockedTokens.TokenHolder>
    (LockedTokens.LockedAccountInfoPublicPath)
-  if lockedAccountInfoCap == nil || !(lockedAccountInfoCap!.check()) {
+  if !(lockedAccountInfoCap!.check()) {
     return unlockedBalance
   }
   let lockedAccountInfoRef = lockedAccountInfoCap!.borrow()!

--- a/docs/tools/flow-js-testing/api.md
+++ b/docs/tools/flow-js-testing/api.md
@@ -845,7 +845,7 @@ describe("interactions - sendTransaction", () => {
   test("basic transaction", async () => {
     const code = `
       transaction(message: String){
-        prepare(singer: AuthAccount){
+        prepare(singer: &Account){
           log(message)
         }
       }
@@ -917,7 +917,7 @@ describe("interactions - sendTransaction", () => {
   test("basic transaction", async () => {
     const code = `
       transaction(message: String){
-        prepare(singer: AuthAccount){
+        prepare(singer: &Account){
           panic("You shall not pass!")
         }
       }
@@ -1174,7 +1174,7 @@ const main = async () => {
   // Define code and arguments we want to pass
   const code = `
     transaction(message: String){
-      prepare(signer: AuthAccount){
+      prepare(signer: &Account){
         log(message)
       }
     }
@@ -1556,8 +1556,8 @@ const main = async () => {
   await sendTransaction({
     code: `
         transaction{
-          prepare(signer: AuthAccount){
-            signer.save(42, to: /storage/answer)
+          prepare(signer: auth(StoreValue) &Account){
+            signer.storage.save(42, to: /storage/answer)
           }
         }
       `,

--- a/docs/tools/flow-js-testing/jest-helpers.md
+++ b/docs/tools/flow-js-testing/jest-helpers.md
@@ -54,7 +54,7 @@ describe("interactions - sendTransaction", () => {
   test("basic transaction", async () => {
     const code = `
       transaction(message: String){
-        prepare(singer: AuthAccount){
+        prepare(singer: &Account){
           log(message)
         }
       }
@@ -126,7 +126,7 @@ describe("interactions - sendTransaction", () => {
   test("basic transaction", async () => {
     const code = `
       transaction(message: String){
-        prepare(singer: AuthAccount){
+        prepare(singer: &Account){
           panic("You shall not pass!")
         }
       }

--- a/docs/tools/flow-js-testing/send-transactions.md
+++ b/docs/tools/flow-js-testing/send-transactions.md
@@ -56,7 +56,7 @@ const main = async () => {
   // Define code and arguments we want to pass
   const code = `
     transaction(message: String){
-      prepare(signer: AuthAccount){
+      prepare(signer: &Account){
         log(message)
       }
     }

--- a/docs/tools/nft-catalog/index.mdx
+++ b/docs/tools/nft-catalog/index.mdx
@@ -4,11 +4,28 @@ sidebar_label: NFT Catalog
 description: The NFT Catalog is an on chain registry listing NFT collections that exists on Flow which adhere to the NFT metadata standard.
 ---
 
-The NFT Catalog is an on chain registry listing NFT collections that exists on Flow which adhere to the NFT metadata standard. This empowers dApp developers to easily build on top of and discover interoperable NFT collections on Flow.
+<Callout type="info">
+
+The NFT Catalog is in the process of being deprecated.
+You can still use it for existing collections in the Catalog,
+but no new collections will be added from now on.
+Most of the functionality that the Catalog provided is now required
+and handled by default by the NonFungibleToken standard with Metadata Views.
+
+Additionally, [TokenList](https://token-list.fixes.world) is a new permissionless tool that
+provides some of the old aggregation functionality that NFT Catalog
+provided without requiring approvals.
+
+</Callout>
+
+The NFT Catalog is an on chain registry listing NFT collections
+that exists on Flow which adhere to the NFT metadata standard.
+This empowers dApp developers to easily build on top of
+and discover interoperable NFT collections on Flow.
 
 ## Live Site
 
-Checkout the catalog [site](https://www.flow-nft-catalog.com/) to submit your NFT collection both on testnet and mainnet.
+Checkout the catalog [site](https://www.flow-nft-catalog.com/)
 
 ## Contract Addresses
 
@@ -26,54 +43,13 @@ Checkout the catalog [site](https://www.flow-nft-catalog.com/) to submit your NF
 | Mainnet | 0x49a7cda3a1eecc29 |
 | Testnet | 0x324c34e1c517e4db |
 
-## Submitting a Collection to the NFT Catalog
-
-1. Visit [here](https://www.flow-nft-catalog.com/v)
-2. Enter the address containing the NFT contract which contains the collection and select the contract.
-
- <img width="1509" alt="Screen Shot 2023-02-08 at 9 40 01 AM" src="https://user-images.githubusercontent.com/5430668/217561873-54beb50e-0ea2-46fb-b9f8-8dbe758ee12f.png" />
-
-3. Enter the storage path where the NFTs are stored and enter an address that holds a sample NFT or log in if you have access to an account that owns the NFT.
-   <img width="1508" alt="Screen Shot 2023-02-08 at 9 42 54 AM" src="https://user-images.githubusercontent.com/5430668/217562366-e6cbf3cb-38b8-45cb-943e-e20185565743.png" />
-
-4. The application will verify that your NFT collection implements the required Metadata views.
-
-    1. The required metadata views include…
-        1. NFT Display
-            1. How to display an individual NFT part of the collection
-        2. External URL
-            1. A website for the NFT collection
-        3. Collection Data
-            1. Information needed to store and retrieve an NFT
-        4. Collection Display
-            1. How to display information about the NFT collection the NFT belongs to
-        5. Royalties
-            1. Any royalties that should be accounted for during marketplace transactions
-    2. You can find sample implementations of all these views in this example NFT [contract](https://github.com/onflow/flow-nft/blob/master/contracts/ExampleNFT.cdc).
-    3. If you are not implementing a view, the app will communicate this and you can update your NFT contract and try resubmitting.
-
-     <img width="738" alt="Screen Shot 2023-02-08 at 9 46 56 AM" src="https://user-images.githubusercontent.com/5430668/217563435-86863297-183b-4345-9615-61f9d4212fe9.png" />
-
-5. Submit proposal transaction to the NFT catalog by entering a unique url safe identifier for the collection and a message including any additional context (like contact information).
-
- <img width="1503" alt="Screen Shot 2023-02-08 at 9 48 45 AM" src="https://user-images.githubusercontent.com/5430668/217563785-65065f51-37bc-49c7-8b3e-ba5d1dda3b24.png" />
-
-6. Once submitted you can view all proposals [here](https://www.flow-nft-catalog.com/proposals/mainnet) to track the review of your NFT.
-
-If you would like to make a proposal manually, you may submit the following transaction with all parameters filled in: [https://github.com/dapperlabs/nft-catalog/blob/main/cadence/transactions/propose_nft_to_catalog.cdc](https://github.com/dapperlabs/nft-catalog/blob/main/cadence/transactions/propose_nft_to_catalog.cdc)
-
-Proposals should be reviewed and approved within a few days. Reasons for a proposal being rejected may include:
-
--   Providing duplicate path or name information of an existing collection on the catalog
--   Providing a not url safe or inaccurate name as the identifier
-
 ## Using the Catalog (For marketplaces and other NFT applications)
 
 All of the below examples use the catalog in mainnet, you may replace the imports to the testnet address when using the testnet network.
 
 **Example 1 - Retrieve all NFT collections on the catalog**
 
-```swift
+```cadence
 import NFTCatalog from 0x49a7cda3a1eecc29
 
 /*
@@ -90,7 +66,7 @@ access(all) fun main(): {String : NFTCatalog.NFTCatalogMetadata} {
 
 **Example 2 - Retrieve all collection names in the catalog**
 
-```swift
+```cadence
 import NFTCatalog from 0x49a7cda3a1eecc29
 
 access(all) fun main(): [String] {
@@ -105,7 +81,7 @@ access(all) fun main(): [String] {
 
 **Example 3 - Retrieve NFT collections and counts owned by an account**
 
-```swift
+```cadence
 import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
@@ -123,7 +99,7 @@ access(all) fun main(ownerAddress: Address) : {String : Number} {
             tempPublicPath,
             target: value.collectionData.storagePath
         )
-        let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+        let collectionCap = account.capabilities.get<&{MetadataViews.ResolverCollection}>(tempPublicPath)
         if !collectionCap.check() {
             continue
         }
@@ -147,7 +123,7 @@ access(all) fun main(ownerAddress: Address) : {String : Number} {
 
 **Example 4 - Retrieve all NFTs including metadata owned by an account**
 
-```swift
+```cadence
 import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
@@ -208,7 +184,7 @@ access(all) struct NFT {
 
 access(all) fun main(ownerAddress: Address) : { String : [NFT] } {
     let catalog = NFTCatalog.getCatalog()
-    let account = getAuthAccount(ownerAddress)
+    let account = getAuthAccount<auth(Capabilities) &Account>(ownerAddress)
     let items : [NFTRetrieval.BaseNFTViewsV1] = []
 
     let data : {String : [NFT] } = {}
@@ -217,11 +193,11 @@ access(all) fun main(ownerAddress: Address) : { String : [NFT] } {
         let value = catalog[key]!
         let tempPathStr = "catalog".concat(key)
         let tempPublicPath = PublicPath(identifier: tempPathStr)!
-        account.link<&{MetadataViews.ResolverCollection}>(
-            tempPublicPath,
-            target: value.collectionData.storagePath
-        )
-        let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+        let newCap = account.capabilities.issue<&{MetadataViews.ResolverCollection}>
+            (value.collectionData.storagePath)
+        account.capabilities.publish(newCap, tempPublicPath)
+
+        let collectionCap = account.capabilities.get<&{MetadataViews.ResolverCollection}>(tempPublicPath)
         if !collectionCap.check() {
             continue
         }
@@ -298,14 +274,14 @@ access(all) fun main(ownerAddress: Address) : { String : [NFT] } {
 
 For Wallets that have a lot of NFTs you may run into memory issues. The common pattern to get around this for now is to retrieve just the ID's in a wallet by calling the following script
 
-```swift
+```cadence
 import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
 
 access(all) fun main(ownerAddress: Address) : {String : [UInt64]} {
     let catalog = NFTCatalog.getCatalog()
-    let account = getAuthAccount(ownerAddress)
+    let account = getAuthAccount<auth(Capabilities) &Account>(ownerAddress)
 
     let items : {String : [UInt64]} = {}
 
@@ -313,12 +289,11 @@ access(all) fun main(ownerAddress: Address) : {String : [UInt64]} {
         let value = catalog[key]!
         let tempPathStr = "catalogIDs".concat(key)
         let tempPublicPath = PublicPath(identifier: tempPathStr)!
-        account.link<&{MetadataViews.ResolverCollection}>(
-            tempPublicPath,
-            target: value.collectionData.storagePath
-        )
+        let newCap = account.capabilities.issue<&{MetadataViews.ResolverCollection}>
+            (value.collectionData.storagePath)
+        account.capabilities.publish(newCap, tempPublicPath)
 
-        let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+        let collectionCap = account.capabilities.get<&{MetadataViews.ResolverCollection}>(tempPublicPath)
         if !collectionCap.check() {
             continue
         }
@@ -336,7 +311,7 @@ access(all) fun main(ownerAddress: Address) : {String : [UInt64]} {
 
 and then use the ids to retrieve the full metadata for only those ids by calling the following script and passing in a map of collectlionIdentifer -> [ids]
 
-```swift
+```cadence
 import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
@@ -397,18 +372,17 @@ access(all) fun main(ownerAddress: Address, collections: {String : [UInt64]}) : 
     let data : {String : [NFT] } = {}
 
     let catalog = NFTCatalog.getCatalog()
-    let account = getAuthAccount(ownerAddress)
+    let account = getAuthAccount<auth(Capabilities) &Account>(ownerAddress)
     for collectionIdentifier in collections.keys {
         if catalog.containsKey(collectionIdentifier) {
             let value = catalog[collectionIdentifier]!
             let tempPathStr = "catalog".concat(collectionIdentifier)
             let tempPublicPath = PublicPath(identifier: tempPathStr)!
-            account.link<&{MetadataViews.ResolverCollection}>(
-                tempPublicPath,
-                target: value.collectionData.storagePath
-            )
+            let newCap = account.capabilities.issue<&{MetadataViews.ResolverCollection}>
+                (value.collectionData.storagePath)
+            account.capabilities.publish(newCap, tempPublicPath)
 
-            let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+            let collectionCap = account.capabilities.get<&{MetadataViews.ResolverCollection}>(tempPublicPath)
 
             if !collectionCap.check() {
                 return data
@@ -463,7 +437,7 @@ access(all) fun main(ownerAddress: Address, collections: {String : [UInt64]}) : 
 
 If you're looking for some MetadataViews that aren't in the [core view list](https://github.com/onflow/flow-nft/blob/master/contracts/MetadataViews.cdc#L36) you can leverage this script to grab all the views each NFT supports. Note: You lose some typing here but get more data.
 
-```swift
+```cadence
 import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
@@ -471,28 +445,22 @@ import NFTRetrieval from 0x49a7cda3a1eecc29
 access(all) struct NFTCollectionData {
     access(all) let storagePath : StoragePath
     access(all) let publicPath : PublicPath
-    access(all) let privatePath: PrivatePath
     access(all) let publicLinkedType: Type
-    access(all) let privateLinkedType: Type
 
     init(
             storagePath : StoragePath,
             publicPath : PublicPath,
-            privatePath : PrivatePath,
             publicLinkedType : Type,
-            privateLinkedType : Type,
     ) {
         self.storagePath = storagePath
         self.publicPath = publicPath
-        self.privatePath = privatePath
         self.publicLinkedType = publicLinkedType
-        self.privateLinkedType = privateLinkedType
     }
 }
 
 access(all) fun main(ownerAddress: Address) : { String : {String : AnyStruct} }  {
     let catalog = NFTCatalog.getCatalog()
-    let account = getAuthAccount(ownerAddress)
+    let account = getAuthAccount<auth(Capabilities) &Account>(ownerAddress)
     let items : [MetadataViews.NFTView] = []
 
     let data : { String : {String : AnyStruct} } = {}
@@ -501,11 +469,10 @@ access(all) fun main(ownerAddress: Address) : { String : {String : AnyStruct} } 
         let value = catalog[key]!
         let tempPathStr = "catalog".concat(key)
         let tempPublicPath = PublicPath(identifier: tempPathStr)!
-        account.link<&{MetadataViews.ResolverCollection}>(
-            tempPublicPath,
-            target: value.collectionData.storagePath
-        )
-        let collectionCap = account.getCapability<&AnyResource{MetadataViews.ResolverCollection}>(tempPublicPath)
+        let newCap = account.capabilities.issue<&{MetadataViews.ResolverCollection}>
+            (value.collectionData.storagePath)
+        account.capabilities.publish(newCap, tempPublicPath)
+        let collectionCap = account.capabilities.get<&{MetadataViews.ResolverCollection}>(tempPublicPath)
         if !collectionCap.check() {
             continue
         }
@@ -521,9 +488,7 @@ access(all) fun main(ownerAddress: Address) : { String : {String : AnyStruct} } 
         let collectionDataView = NFTCollectionData(
                     storagePath : nftCollectionDisplayView!.storagePath,
                     publicPath : nftCollectionDisplayView!.publicPath,
-                    privatePath : nftCollectionDisplayView!.providerPath,
                     publicLinkedType : nftCollectionDisplayView!.publicLinkedType,
-                    privateLinkedType : nftCollectionDisplayView!.providerLinkedType,
         )
         views.insert(key: Type<MetadataViews.NFTCollectionData>().identifier, collectionDataView)
 
@@ -538,7 +503,7 @@ access(all) fun main(ownerAddress: Address) : { String : {String : AnyStruct} } 
 
 1. Run the following script to retrieve some collection-level information for an NFT collection identifier from the catalog
 
-```swift
+```cadence
 import MetadataViews from 0x1d7e57aa55817448
 import NFTCatalog from 0x49a7cda3a1eecc29
 import NFTRetrieval from 0x49a7cda3a1eecc29
@@ -601,31 +566,77 @@ access(all) fun main(collectionIdentifier : String) : NFT? {
 
 2. This script result can then be used to form a transaction by inserting the relevant variables from above into a transaction template like the following:
 
-```swift
+```cadence
 import NonFungibleToken from 0x1d7e57aa55817448
 import MetadataViews from 0x1d7e57aa55817448
 {ADDITIONAL_IMPORTS}
 
 transaction {
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(BorrowValue, IssueStorageCapabilityController, PublishCapability, SaveValue, UnpublishCapability) &Account) {
+        
+        let collectionData = {CONTRACT_NAME}.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>()) as! MetadataViews.NFTCollectionData?
+            ?? panic("Could not resolve NFTCollectionData view. The {CONTRACT_NAME} contract needs to implement the NFTCollectionData Metadata view in order to execute this transaction")
+
+        // Return early if the account already has a collection
+        if signer.storage.borrow<&{CONTRACT_NAME}.Collection>(from: collectionData.storagePath) != nil {
+            return
+        }
+
         // Create a new empty collection
-        let collection <- {CONTRACT_NAME}.createEmptyCollection()
+        let collection <- {CONTRACT_NAME}.createEmptyCollection(nftType: Type<@{CONTRACT_NAME}.NFT>())
 
         // save it to the account
-        signer.save(<-collection, to: {STORAGE_PATH})
+        signer.storage.save(<-collection, to: collectionData.storagePath)
 
         // create a public capability for the collection
-        signer.link<&{PUBLIC_LINKED_TYPE}>(
-            {PUBLIC_PATH},
-            target: {STORAGE_PATH}
-        )
+        signer.capabilities.unpublish(collectionData.publicPath)
+        let collectionCap = signer.capabilities.storage.issue<&{CONTRACT_NAME}.Collection>(collectionData.storagePath)
+        signer.capabilities.publish(collectionCap, at: collectionData.publicPath)
+    }
+}
 
-				// create a private capability for the collection
-        signer.link<&{PRIVATE_LINKED_TYPE}>(
-            {PRIVATE_PATH},
-            target: {STORAGE_PATH}
-        )
+```
+
+An even easier way to setup an account without relying
+on the NFT Catalog is to just use the generic setup account transaction.
+All you need is the name and address of the contract!
+```cadence
+import "NonFungibleToken"
+import "MetadataViews"
+
+/// This transaction is what an account would run
+/// to set itself up to receive NFTs. This function
+/// uses views to know where to set up the collection
+/// in storage and to create the empty collection.
+///
+/// @param contractAddress: The address of the contract that defines the token being initialized
+/// @param contractName: The name of the contract that defines the token being initialized. Ex: "ExampleNFT"
+
+transaction(contractAddress: Address, contractName: String) {
+
+    prepare(signer: auth(IssueStorageCapabilityController, PublishCapability, SaveValue) &Account) {
+        // Borrow a reference to the nft contract deployed to the passed account
+        let resolverRef = getAccount(contractAddress)
+            .contracts.borrow<&{NonFungibleToken}>(name: contractName)
+                ?? panic("Could not borrow NonFungibleToken reference to the contract. Make sure the provided contract name ("
+                         .concat(contractName).concat(") and address (").concat(contractAddress.toString()).concat(") are correct!"))
+
+        // Use that reference to retrieve the NFTCollectionData view 
+        let collectionData = resolverRef.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>()) as! MetadataViews.NFTCollectionData?
+            ?? panic("Could not resolve NFTCollectionData view. The ".concat(contractName).concat(" contract needs to implement the NFTCollectionData Metadata view in order to execute this transaction"))
+
+        // Create a new empty collections
+        let emptyCollection <- collectionData.createEmptyCollection()
+
+        // save it to the account
+        signer.storage.save(<-emptyCollection, to: collectionData.storagePath)
+
+        // create a public capability for the collection
+        let collectionCap = signer.capabilities.storage.issue<&{NonFungibleToken.Collection}>(
+                collectionData.storagePath
+            )
+        signer.capabilities.publish(collectionCap, at: collectionData.publicPath)
     }
 }
 ```


### PR DESCRIPTION
Closes #554 
Closes #832 
Closes #559 
Closes #560 
Closes #562 
Closes #564 

Updates all Cadence code to use C1.0 syntax. I created https://github.com/onflow/docs/issues/924 to track the account linking docs updates because I don't feel fully equipped to make the correct changes there myself.

I didn't test all the cadence updates, so there may be a few syntax errors