### PR TITLE
removing refernces of Metrika dashboard

### DIFF
--- a/docs/networks/node-ops/access-onchain-data/access-nodes/access-node-setup.mdx
+++ b/docs/networks/node-ops/access-onchain-data/access-nodes/access-node-setup.mdx
@@ -39,7 +39,7 @@ Confirmation of a new node's inclusion in epoch N+1 is included in the [`EpochSe
 ## Limitations
 
 There are five open slots for access nodes every epoch.
-You can view the exact epoch phase transition time [here](https://app.metrika.co/flow/dashboard/network-overview?tr=1d) under `Epoch Phase`.
+You can view the exact epoch phase transition time [here](https://dashboard.flow.com/) under `Epoch Phase`.
 
 To summarize,
 

--- a/docs/networks/node-ops/node-operation/monitoring-nodes.md
+++ b/docs/networks/node-ops/node-operation/monitoring-nodes.md
@@ -91,8 +91,3 @@ The metrics include the account address of the machine account (`acct_address` l
 machine_account_balance{acct_address="7b16b57ae0a3c6aa"} 9.99464935
 ```
 
-## Monitoring a Flow node using Metrika Monitoring
-
-Metrika has developed the Flow node monitoring service and is the recommended way of monitoring a Flow node.
-It is a free tool that uses the logs and metrics published by the node and provides access to private node-specific dashboards.
-Follow this [link](https://app.metrika.co/flow/node/install-agent) to setup the Metrika monitoring for your node.

--- a/docs/networks/node-ops/node-operation/protocol-state-bootstrap.md
+++ b/docs/networks/node-ops/node-operation/protocol-state-bootstrap.md
@@ -113,7 +113,7 @@ Two flags are used to specify when to bootstrap:
 - `--dynamic-startup-epoch-phase` - the epoch phase to start up in (default `EpochPhaseSetup`)
 - `--dynamic-startup-epoch` - the epoch counter to start up in (default `current`)
 
-> You can check the current epoch phase of the network by running [this](https://github.com/onflow/flow-core-contracts/blob/master/transactions/epoch/scripts/get_epoch_phase.cdc) script. Alternatively, you can also check the current epoch phase [here](https://app.metrika.co/flow/dashboard/network-overview) under Epoch Phase.
+> You can check the current epoch phase of the network by running [this](https://github.com/onflow/flow-core-contracts/blob/master/transactions/epoch/scripts/get_epoch_phase.cdc) script. Alternatively, you can also check the current epoch phase [here](https://dashboard.flow.com/) under Epoch Phase.
 
 #### Bootstrapping Immediately
 


### PR DESCRIPTION
Metrika has decommissioned Flow dashboard. This change is replace all references to the public dashboard to the on setup by foundation at dashboard.flow.com