### PR TITLE
Fix Add to MM button -  expects  `0x` String

### DIFF
--- a/src/components/addNetworkButton.tsx
+++ b/src/components/addNetworkButton.tsx
@@ -62,7 +62,7 @@ export const AddNetworkButton = (): JSX.Element => {
         method: 'wallet_addEthereumChain',
         params: [
           {
-            chainId: id.toString(16), // '0x2eb', // 747 in hexadecimal
+            chainId: `0x${id.toString(16)}`, // '0x2eb', // 747 in hexadecimal
             chainName: name,
             rpcUrls,
             iconUrls: [
@@ -72,7 +72,7 @@ export const AddNetworkButton = (): JSX.Element => {
               name: 'Flow',
               symbol: 'FLOW',
               decimals: 18,
-           },
+            },
             blockExplorerUrls,
           },
         ],


### PR DESCRIPTION
The add to MetaMask button at https://developers.flow.com/evm/using is broken.

MetaMask RPC expects a `0x` prefix on the hex string for network Id.

PR adds the prefix.