### PR TITLE
Update supported endpoints for EVM

### DIFF
--- a/docs/evm/using.mdx
+++ b/docs/evm/using.mdx
@@ -102,7 +102,7 @@ To use the Flow Wallet Chrome extension:
 | [eth_getFilterLogs]                       | ✅     |
 | [eth_getLogs]                             | ✅     |
 | [eth_getProof]                            | 🚧     | Unsupported |
-| [eth_getStorageAt]                        | 🚧     | Unsupported |
+| [eth_getStorageAt]                        | ✅     |
 | [eth_getTransactionByBlockHashAndIndex]   | ✅     |
 | [eth_getTransactionByBlockNumberAndIndex] | ✅     |
 | [eth_getTransactionByHash]                | ✅     |

--- a/docs/evm/using.mdx
+++ b/docs/evm/using.mdx
@@ -126,6 +126,7 @@ To use the Flow Wallet Chrome extension:
 | [debug_traceTransaction]                  | ✅     |
 | [debug_traceBlockByNumber]                | ✅     |
 | [debug_traceBlockByHash]                  | ✅     |
+| [debug_traceCall]                         | ✅     |
 
 **Legend**: ❌ = not supported. 🚧 = work in progress. ✅ = supported.
 


### PR DESCRIPTION
`eth_getStorageAt` and `debug_traceCall` are supported on mainnet and testnet but were flagged otherwise in docs.
