### PR TITLE
Tune Why Flow and add MEV Resistance doc

### DIFF
--- a/docs/build/basics/mev-resistance.md
+++ b/docs/build/basics/mev-resistance.md
@@ -1,0 +1,75 @@
+---
+title: MEV Resistance
+description: How Flow’s unique architecture minimizes Maximal Extractable Value (MEV) to ensure fair and equitable access.
+sidebar_position: 5
+keywords:
+  - MEV
+  - Maximal Extractable Value
+  - Flow Blockchain
+  - Equitable Access
+  - Transaction Ordering
+  - Blockchain Security
+---
+
+# How Flow Suppresses MEV to Ensure Equitable Access  
+
+## The Hidden Cost of MEV in Decentralized Systems  
+
+One of the most under-discussed benefits of decentralization is **equitable access**. Ideally, the value and quality-of-service you receive from a decentralized platform should not depend on your identity, computing power, or personal connections. However, **Maximal Extractable Value (MEV)** poses a significant threat to this principle.  
+
+MEV allows block producers to manipulate transaction ordering for profit—often at the direct expense of users. The ability to front-run, back-run, or sandwich transactions can extract value from ordinary users, reinforcing inequalities rather than eliminating them. In most blockchain networks, MEV is not just an unfortunate side effect; it is structurally embedded in how transactions are processed.  
+
+## Why MEV Persists on Most Blockchains  
+
+MEV is difficult to prevent on most blockchains because **each block has a single builder**. This builder must have:  
+
+- A full copy of the blockchain state  
+- The ability to simulate transactions before they are finalized  
+- Absolute control over transaction selection and ordering  
+
+In practice, this means that **the entity responsible for adding your transaction to the blockchain can first simulate it to identify profit opportunities**. They can test hundreds or thousands of ways to rearrange transactions, inserting their own to extract MEV—often at **your** expense.  
+
+For example, if a block builder can earn $10 by sandwiching your transaction, it means **you** likely lose $10 in value. This is functionally theft, and the worst part? If your transaction is airtight and offers no MEV opportunities, the block builder has no obligation to include it at all. Pay the toll, or get locked out.  
+
+## How Flow Mitigates MEV  
+
+Unlike many blockchains, **Flow was designed from the ground up to minimize MEV** through a unique multi-role architecture. Flow introduces key design choices that break the typical MEV-enabling structure:  
+
+### 1. **Separating Transaction Selection from Execution**  
+On Flow, **Collection Nodes** select transactions, but they do not have access to the execution state or computing power to simulate them. Meanwhile, **Execution Nodes** run transactions but cannot choose or reorder them.  
+
+This separation significantly reduces the ability of block builders to test transactions before execution. Even if an attacker controls both a Collection Node and an Execution Node, they cannot easily extract MEV.  
+
+### 2. **Separating Transaction Ordering from Execution**  
+Flow further decentralizes control by introducing **Consensus Nodes** that determine transaction order. These nodes are separate from both Collection Nodes and Execution Nodes.  
+
+For an attacker to perform MEV, they would need to:  
+- Control a **Collection Node** to insert a transaction  
+- Control a **Consensus Node** to place it in the desired order  
+- Have execution state access to predict its effects  
+
+This makes it vastly more difficult to extract MEV compared to traditional blockchains, where a single entity often controls all three functions.  
+
+### 3. **Strict Transaction Execution Rules**  
+Execution Nodes on Flow have a **simple, enforceable rule**:  
+They **must** execute transactions exactly as ordered by Consensus Nodes—or they get slashed.  
+
+Unlike traditional blockchains, where the same party both orders and executes transactions, Flow ensures that Execution Nodes cannot manipulate transaction order for profit.  
+
+### 4. **Parallel Processing for Extra MEV Resistance**  
+Flow’s unique **pipelined execution model** adds another layer of complexity for potential attackers.  
+
+While one block is being executed, the next block is undergoing consensus, and a third block is still collecting transactions. This means that **to front-run or sandwich attack on Flow, an attacker must successfully predict the outcome of at least two unexecuted blocks—one of which hasn’t even been built yet**.  
+
+Even with significant resources, this makes profitable MEV attacks incredibly difficult.  
+
+## The End Result: A Fairer Blockchain  
+
+Flow’s architecture ensures that:  
+- The nodes selecting transactions **don’t know** their order  
+- The nodes ordering transactions **don’t know** the blockchain state  
+- The nodes executing transactions **can’t** modify the order  
+
+By **intentionally separating powers**, Flow eliminates MEV at its root rather than merely mitigating its effects.  
+
+This level of protection against MEV is not an afterthought—it has been a fundamental design goal of Flow since day one. If equitable access matters, **why settle for anything less?**

--- a/docs/build/flow.md
+++ b/docs/build/flow.md
@@ -19,6 +19,9 @@ keywords:
   - blockchain architecture
   - decentralization
   - consumer apps
+  - MEV
+  - miner-extractable value
+  - maximum extractable value
 ---
 
 
@@ -51,6 +54,7 @@ Flow is a fast, decentralized, and developer-friendly blockchain designed to be 
 - **Multi-role architecture:** The [multi-role architecture] of Flow allows the network to [scale without sharding] to serve billions of users without reducing the decentralization of consensus and verification.
 - **True Fast Finality**: For most other networks, it takes minutes, [a day], or even [a week] to reach hard finality - the point in which a transaction cannot be reversed.  On Flow, the median time for finality is [under 10 seconds], without compromising security.
 - **Native VRF**: Flow provides [onchain randomness] at the protocol level.  Instead of implementing a complex setup and [paying $10+ USD per number], simply call the built-in function.
+- **MEV Resistance**: Flow is designed to [ensure equitable access] by resisting MEV.  Maximum Extractable Value, also know as Miner-Extractable Value (MEV), is a practice common in other blockchains in which the builder of a block can profit at your expense by manipulating where and how your transaction is included.  
 - **Consumer Onboarding:** Flow was designed for mainstream consumers, with payment onramps catalyzing a safe and low-friction path from fiat to crypto.
 - **EVM Equivalence**: The [Cadence] Virtual Machine (VM) is powerful enough to allow other VMs to run inside of it, almost like a Docker Container.  The first one integrated in this way is [EVM] and the EVM RPC API.
 - **Efficient Gas Costs**: The Flow blockchain is extremely efficient, allowing apps to do more computation at lower costs. 
@@ -67,7 +71,7 @@ Flow is a fast, decentralized, and developer-friendly blockchain designed to be 
 - **Speed, Cost, and Compatibility**: Flow EVM can already run all of your audited Solidity contracts at an average of less than 1 cent per transaction ([usually way less!]).  Unlike L2 solutions, Flow EVM reaches true finality in seconds - not in [a week]. 😳
 - **Bridge from Other EVM Networks**: You can [bridge] hundreds of assets from dozens of chains to Flow.
 - **VM Token Bridge**: Assets can be bridged between Flow Cadence and Flow EVM easily and atomically with the VM token bridge. Assets can even be bridged **and used** in a **single** transaction, allowing full composability between the EVM and Cadence environments.
-- **Access to Cadence**: Access Cadence features and contracts from Flow EVM to take advantage of native [VRF], higher computation for lower cost, and any asset on Cadence Flow.
+- **Access to Cadence**: Access Cadence features and contracts from Flow EVM to take advantage of native [VRF], higher computation for lower cost, and any asset on Cadence Flow.  You can also build [cross-vm apps] on top of the wagmi/viem/RainbowKit stack, enabling batched transactions and more.
 - **EVM Equivalence:** Flow EVM is truly _EVM Equivalent_, not just _EVM Compatible_.  It runs exactly the same as EVM mainnet, which means builders won't run into "minor" variances or endless "quirks" when they try to integrate.  If it works on Ethereum Mainnet, it will work with Flow EVM.
 
 ## Learning Shortcuts
@@ -141,6 +145,7 @@ The [FLOW] (or $FLOW) token is the native currency for the Flow network. Develop
 [multi-role architecture]: https://www.onflow.org/primer
 [onchain randomness]: ./advanced-concepts/randomness.md
 [paying $10+ USD per number]: https://docs.chain.link/vrf/v2-5/billing
+[ensure equitable access]: ./basics/mev-resistance.md
 [scale without sharding]: https://www.onflow.org/post/flow-blockchain-multi-node-architecture-advantages
 [a day]: https://docs.zksync.io/zk-stack/concepts/finality#finality-on-zksync-era
 [a week]: https://docs.optimism.io/stack/rollup/overview#fault-proofs
@@ -154,6 +159,7 @@ The [FLOW] (or $FLOW) token is the native currency for the Flow network. Develop
 [Guide for Solidity Developers]: https://cadence-lang.org/docs/solidity-to-cadence
 [account abstraction]: https://flow.com/account-abstraction
 [bridge]: ../ecosystem/bridges.md
+[cross-vm apps]: ../tutorials/cross-vm-apps/index.md
 [Getting Started]: ./getting-started/contract-interaction.md
 [core contracts]: ./core-contracts/index.md
 [FLOW]: ./core-contracts/03-flow-token.md

--- a/docs/templates/tutorial.md
+++ b/docs/templates/tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: Title, same as below
+title: Title, shorten if necessary, will be on sidebar
 description: A one sentence description.
 sidebar_position: 5
 keywords:
@@ -8,6 +8,8 @@ keywords:
   - the main topics
   - cursor is great at this
 ---
+
+# Title
 
 1-2 Paragraphs describing what the tutorial will teach, why someone might learn it, and if possible, a link to a live version of the app demoing the techniques and content taught.
 


### PR DESCRIPTION
Add MEV resistance to Why Flow and an article made from Dete's tweets about it.

Closes: https://github.com/orgs/onflow/projects/85?pane=issue&itemId=100738695&issue=onflow%7Cdev-rel%7C46