### PR TITLE
Correct GTAG Page Location Params

### DIFF
--- a/src/components/feedbackFaces.tsx
+++ b/src/components/feedbackFaces.tsx
@@ -18,7 +18,6 @@ export default function FeedbackFaces() {
             category: "feedback",
             label: feedbackType,
             value: feedbackType === "happy" ? 2 : feedbackType === "neutral" ? -1 : -2,
-            location: true
         });
 
         setTimeout(() => setClickedFace(null), 300);

--- a/src/components/feedbackFaces.tsx
+++ b/src/components/feedbackFaces.tsx
@@ -13,13 +13,12 @@ export default function FeedbackFaces() {
     const handleFeedbackClick = (feedbackType: string) => {
         setClickedFace(feedbackType);
 
-        const label = `${feedbackType}`;
-
         event({
             action: "feedback_click",
             category: "feedback",
-            label: label,
-            location: true,
+            label: feedbackType,
+            value: feedbackType === "happy" ? 2 : feedbackType === "neutral" ? -1 : -2,
+            location: true
         });
 
         setTimeout(() => setClickedFace(null), 300);

--- a/src/utils/gtags.client.ts
+++ b/src/utils/gtags.client.ts
@@ -36,14 +36,12 @@ export const event = ({
   action = "unknown",
   category,
   label,
-  value,
-  location
+  value
 }: {
   action?: string;
   category?: string;
   label?: string;
   value?: number | string;
-  location?: boolean;
 }) => {
   if (process.env.NODE_ENV !== "production") return
 

--- a/src/utils/gtags.client.ts
+++ b/src/utils/gtags.client.ts
@@ -58,11 +58,10 @@ export const event = ({
     event_category: category,
     event_label: label,
     value: value,
+    page_title: document.title,
+    page_location: window.location.href,
+    page_path: window.location.pathname,
   };
-
-  if (location) {
-    eventPayload.page_location = window.location.href;
-  }
 
   window.gtag("event", action, eventPayload);
 }


### PR DESCRIPTION
Previous implementation had params for location not recognized by GA.

Update to correct params, including full path and page title.

Added a scoring system for easy surfacing of the best and worst pages.