### PR TITLE
Fix link in bridge contract doc

### DIFF
--- a/docs/build/core-contracts/15-bridge.md
+++ b/docs/build/core-contracts/15-bridge.md
@@ -1,0 +1,81 @@
+---
+title: VM Bridge Contracts
+sidebar_position: 15
+sidebar_label: VM Bridge
+description: Learn about Flow's bridge contracts that manage bridging tokens between the Cadence and EVM environments.
+keywords:
+  - core contracts
+  - transaction fees
+  - EVM
+  - bridge
+  - fungible tokens
+  - non fungible tokens
+  - nft
+---
+
+The Flow VM bridge is the account and series of smart contracts that manage how
+assets are safely bridged between the Cadence and EVM Flow Environments.
+
+| Network                   | Contract Address     |
+| ------------------------- | -------------------- |
+| Emulator                  | `0xf8d6e0586b0a20c7` |
+| Cadence Testing Framework | `0x0000000000000001` |
+| Testnet                   | `0xdfc20aee650fcbdf` |
+| Mainnet                   | `0x1e4aa0b87d10b141` |
+
+# Contracts
+
+There are many important contracts deployed to the bridge account.
+You should refer to [the bridge repo](https://github.com/onflow/flow-evm-bridge)
+and [the bridge guides](../../evm/cadence/vm-bridge.md)
+for more detailed information about the bridge and tutorials for how to use the bridge properly.
+
+Here is a list of each Cadence contract used for the bridge:
+
+| Contract                              | Purpose                                                                                                   |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `CrossVMNFT`                          | Contract defining cross-VM NFT-related interfaces                                                         |
+| `CrossVMToken`                        | Contract defining cross-VM Fungible Token Vault interface                                                 |
+| `FlowEVMBridgeHandlerInterfaces`      | Defines interface for custom bridged token handlers                                                       |
+| `IBridgePermissions`                  | Defines an interface to prevent bridging for a specific token                                             |
+| `ICrossVM`                            | Defines an interface to get EVM contract addresses                                                        |
+| `ICrossVMAsset`                       | Defines an interface to represent a Cadence bridged version of an EVM asset                               |
+| `IEVMBridgeNFTMinter`                 | Defines an interface that allows the bridge to mint NFTs                                                  |
+| `IEVMBridgeTokenMinter`               | Defines an interface that allows the bridge to mint FTs                                                   |
+| `IFlowEVMNFTBridge`                   | Defines core methods for bridging NFTs                                                                    |
+| `IFlowEVMTokenBridge`                 | Defines core methods for bridging FTs                                                                     |
+| `FlowEVMBridge`                       | The main entrypoint for briding tokens across Flow VMs                                                    |
+| `FlowEVMBridgeAccessor`               | Defines methods to route bridge requests from the EVM contract to the Flow-EVM bridge contract            |
+| `FlowEVMBridgeConfig`                 | Used to store configuration options for the VM Bridge                                                     |
+| `FlowEVMBridgeCustomAssociations`     | Stores configuration information about custom bridged asset configurations                                |
+| `FlowEVMBridgeCustomAssociationTypes` | Defines interfaces used to specify custom bridged asset associations                                      |
+| `FlowEVMBridgeHandlers`               | Defines mechanisms for handling assets with custom associations (Deprecated)                              |
+| `FlowEVMBridgeNFTEscrow`              | Handles locking of NFTs that are bridged from Flow to EVM and back                                        |
+| `FlowEVMBridgeResolver`               | Defines methods to resolve Metadata Views for bridged assets                                              |
+| `FlowEVMBridgeTemplates`              | Serves Cadence code from chunked templates for bridge-deployed assets                                     |
+| `FlowEVMBridgeTokenEscrow`            | Handles locking of FTs that are bridged from Flow to EVM and back                                         |
+| `FlowEVMBridgeUtils`                  | Defines many different utility methods that are used by bridge contracts                                  |
+| `ArrayUtils`                          | Provides useful utility functions for manipulating arrays                                                 |
+| `ScopedFTProviders`                   | Provides utilities for creating provider capabilities for tokens that are restricted to a specific amount |
+| `Serialize`                           | Provides utilities for serializing common types to json-compatible strings                                |
+| `SerializeMetadata`                   | Provides methods for serializing NFT metadata as a JSON compatible string                                 |
+| `StringUtils`                         | Provides useful utility functions for manipulating strings                                                |
+
+# EVM Bridge Solidity Contracts
+
+There are also Solidity contracts that are deployed in Flow EVM that are needed for the bridge.
+Here are their addresses:
+
+| Contracts                             | Testnet                                                                                                                            | Mainnet                                                                                                                    |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `FlowEVMBridgeFactory.sol`            | [`0xf8146b4aef631853f0eb98dbe28706d029e52c52`](https://evm-testnet.flowscan.io/address/0xF8146B4aEF631853F0eB98DBE28706d029e52c52) | [`0x1c6dea788ee774cf15bcd3d7a07ede892ef0be40`](https://evm.flowscan.io/address/0x1C6dEa788Ee774CF15bCd3d7A07ede892ef0bE40) |
+| `FlowEVMBridgeDeploymentRegistry.sol` | [`0x8781d15904d7e161f421400571dea24cc0db6938`](https://evm-testnet.flowscan.io/address/0x8781d15904d7e161f421400571dea24cc0db6938) | [`0x8fdec2058535a2cb25c2f8cec65e8e0d0691f7b0`](https://evm.flowscan.io/address/0x8FDEc2058535A2Cb25C2f8ceC65e8e0D0691f7B0) |
+| `FlowEVMBridgedERC20Deployer.sol`     | [`0x4d45CaD104A71D19991DE3489ddC5C7B284cf263`](https://evm-testnet.flowscan.io/address/0x4d45CaD104A71D19991DE3489ddC5C7B284cf263) | [`0x49631Eac7e67c417D036a4d114AD9359c93491e7`](https://evm.flowscan.io/address/0x49631Eac7e67c417D036a4d114AD9359c93491e7) |
+| `FlowEVMBridgedERC721Deployer.sol`    | [`0x1B852d242F9c4C4E9Bb91115276f659D1D1f7c56`](https://evm-testnet.flowscan.io/address/0x1B852d242F9c4C4E9Bb91115276f659D1D1f7c56) | [`0xe7c2B80a9de81340AE375B3a53940E9aeEAd79Df`](https://evm.flowscan.io/address/0xe7c2B80a9de81340AE375B3a53940E9aeEAd79Df) |
+
+And below are the bridge escrow's EVM addresses. These addresses are [`CadenceOwnedAccount`s (COA)](https://developers.flow.com/tutorials/cross-vm-apps/interacting-with-coa#coa-interface) and they are stored stored in the same Flow account as you'll find the Cadence contracts (see above).
+
+| Network | Address                                                                                                                            |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Testnet | [`0x0000000000000000000000023f946ffbc8829bfd`](https://evm-testnet.flowscan.io/address/0x0000000000000000000000023f946FFbc8829BFD) |
+| Mainnet | [`0x00000000000000000000000249250a5c27ecab3b`](https://evm.flowscan.io/address/0x00000000000000000000000249250a5C27Ecab3B)         |

--- a/docs/build/core-contracts/15-bridge.md
+++ b/docs/build/core-contracts/15-bridge.md
@@ -13,7 +13,7 @@ keywords:
   - nft
 ---
 
-The Flow VM bridge is the account and series of smart contracts that manage how 
+The Flow VM bridge is the account and series of smart contracts that manage how
 assets are safely bridged between the Cadence and EVM Flow Environments.
 
 | Network                   | Contract Address     |
@@ -27,55 +27,55 @@ assets are safely bridged between the Cadence and EVM Flow Environments.
 
 There are many important contracts deployed to the bridge account.
 You should refer to [the bridge repo](https://github.com/onflow/flow-evm-bridge)
-and [the bridge guides](../../evm/cadence/vm-bridge.md)
+and [the bridge guides](../../tutorials/cross-vm-apps/vm-bridge.md)
 for more detailed information about the bridge and tutorials for how to use the bridge properly.
 
 Here is a list of each Cadence contract used for the bridge:
 
-| Contract                   | Purpose     |
-| ------------------------- | -------------------- |
-| `CrossVMNFT`                | Contract defining cross-VM NFT-related interfaces |
-| `CrossVMToken` | Contract defining cross-VM Fungible Token Vault interface |
-| `FlowEVMBridgeHandlerInterfaces` | Defines interface for custom bridged token handlers |
-| `IBridgePermissions` | Defines an interface to prevent bridging for a specific token  |
-| `ICrossVM` | Defines an interface to get EVM contract addresses |
-| `ICrossVMAsset` | Defines an interface to represent a Cadence bridged version of an EVM asset |
-| `IEVMBridgeNFTMinter` | Defines an interface that allows the bridge to mint NFTs |
-| `IEVMBridgeTokenMinter`  | Defines an interface that allows the bridge to mint FTs |
-| `IFlowEVMNFTBridge` | Defines core methods for bridging NFTs |
-| `IFlowEVMTokenBridge` | Defines core methods for bridging FTs |
-| `FlowEVMBridge` | The main entrypoint for briding tokens across Flow VMs |
-| `FlowEVMBridgeAccessor`  | Defines methods to route bridge requests from the EVM contract to the Flow-EVM bridge contract  |
-| `FlowEVMBridgeConfig` | Used to store configuration options for the VM Bridge |
-| `FlowEVMBridgeCustomAssociations` | Stores configuration information about custom bridged asset configurations | 
-| `FlowEVMBridgeCustomAssociationTypes` | Defines interfaces used to specify custom bridged asset associations |
-| `FlowEVMBridgeHandlers` | Defines mechanisms for handling assets with custom associations (Deprecated) |
-| `FlowEVMBridgeNFTEscrow` | Handles locking of NFTs that are bridged from Flow to EVM and back |
-| `FlowEVMBridgeResolver`  | Defines methods to resolve Metadata Views for bridged assets |
-| `FlowEVMBridgeTemplates` | Serves Cadence code from chunked templates for bridge-deployed assets |
-| `FlowEVMBridgeTokenEscrow` | Handles locking of FTs that are bridged from Flow to EVM and back |
-| `FlowEVMBridgeUtils` | Defines many different utility methods that are used by bridge contracts |
-| `ArrayUtils` | Provides useful utility functions for manipulating arrays |
-| `ScopedFTProviders` | Provides utilities for creating provider capabilities for tokens that are restricted to a specific amount |
-| `Serialize` | Provides utilities for serializing common types to json-compatible strings |
-| `SerializeMetadata` | Provides methods for serializing NFT metadata as a JSON compatible string |
-| `StringUtils` | Provides useful utility functions for manipulating strings |
+| Contract                              | Purpose                                                                                                   |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `CrossVMNFT`                          | Contract defining cross-VM NFT-related interfaces                                                         |
+| `CrossVMToken`                        | Contract defining cross-VM Fungible Token Vault interface                                                 |
+| `FlowEVMBridgeHandlerInterfaces`      | Defines interface for custom bridged token handlers                                                       |
+| `IBridgePermissions`                  | Defines an interface to prevent bridging for a specific token                                             |
+| `ICrossVM`                            | Defines an interface to get EVM contract addresses                                                        |
+| `ICrossVMAsset`                       | Defines an interface to represent a Cadence bridged version of an EVM asset                               |
+| `IEVMBridgeNFTMinter`                 | Defines an interface that allows the bridge to mint NFTs                                                  |
+| `IEVMBridgeTokenMinter`               | Defines an interface that allows the bridge to mint FTs                                                   |
+| `IFlowEVMNFTBridge`                   | Defines core methods for bridging NFTs                                                                    |
+| `IFlowEVMTokenBridge`                 | Defines core methods for bridging FTs                                                                     |
+| `FlowEVMBridge`                       | The main entrypoint for briding tokens across Flow VMs                                                    |
+| `FlowEVMBridgeAccessor`               | Defines methods to route bridge requests from the EVM contract to the Flow-EVM bridge contract            |
+| `FlowEVMBridgeConfig`                 | Used to store configuration options for the VM Bridge                                                     |
+| `FlowEVMBridgeCustomAssociations`     | Stores configuration information about custom bridged asset configurations                                |
+| `FlowEVMBridgeCustomAssociationTypes` | Defines interfaces used to specify custom bridged asset associations                                      |
+| `FlowEVMBridgeHandlers`               | Defines mechanisms for handling assets with custom associations (Deprecated)                              |
+| `FlowEVMBridgeNFTEscrow`              | Handles locking of NFTs that are bridged from Flow to EVM and back                                        |
+| `FlowEVMBridgeResolver`               | Defines methods to resolve Metadata Views for bridged assets                                              |
+| `FlowEVMBridgeTemplates`              | Serves Cadence code from chunked templates for bridge-deployed assets                                     |
+| `FlowEVMBridgeTokenEscrow`            | Handles locking of FTs that are bridged from Flow to EVM and back                                         |
+| `FlowEVMBridgeUtils`                  | Defines many different utility methods that are used by bridge contracts                                  |
+| `ArrayUtils`                          | Provides useful utility functions for manipulating arrays                                                 |
+| `ScopedFTProviders`                   | Provides utilities for creating provider capabilities for tokens that are restricted to a specific amount |
+| `Serialize`                           | Provides utilities for serializing common types to json-compatible strings                                |
+| `SerializeMetadata`                   | Provides methods for serializing NFT metadata as a JSON compatible string                                 |
+| `StringUtils`                         | Provides useful utility functions for manipulating strings                                                |
 
-# EVM Bridge Solidity Contracts  
+# EVM Bridge Solidity Contracts
 
 There are also Solidity contracts that are deployed in Flow EVM that are needed for the bridge.
 Here are their addresses:
 
-|Contracts|Testnet|Mainnet|
-|---|---|---|
-|`FlowEVMBridgeFactory.sol`|[`0xf8146b4aef631853f0eb98dbe28706d029e52c52`](https://evm-testnet.flowscan.io/address/0xF8146B4aEF631853F0eB98DBE28706d029e52c52)|[`0x1c6dea788ee774cf15bcd3d7a07ede892ef0be40`](https://evm.flowscan.io/address/0x1C6dEa788Ee774CF15bCd3d7A07ede892ef0bE40)|
-|`FlowEVMBridgeDeploymentRegistry.sol`|[`0x8781d15904d7e161f421400571dea24cc0db6938`](https://evm-testnet.flowscan.io/address/0x8781d15904d7e161f421400571dea24cc0db6938)|[`0x8fdec2058535a2cb25c2f8cec65e8e0d0691f7b0`](https://evm.flowscan.io/address/0x8FDEc2058535A2Cb25C2f8ceC65e8e0D0691f7B0)|
-|`FlowEVMBridgedERC20Deployer.sol`|[`0x4d45CaD104A71D19991DE3489ddC5C7B284cf263`](https://evm-testnet.flowscan.io/address/0x4d45CaD104A71D19991DE3489ddC5C7B284cf263)|[`0x49631Eac7e67c417D036a4d114AD9359c93491e7`](https://evm.flowscan.io/address/0x49631Eac7e67c417D036a4d114AD9359c93491e7)|
-|`FlowEVMBridgedERC721Deployer.sol`|[`0x1B852d242F9c4C4E9Bb91115276f659D1D1f7c56`](https://evm-testnet.flowscan.io/address/0x1B852d242F9c4C4E9Bb91115276f659D1D1f7c56)|[`0xe7c2B80a9de81340AE375B3a53940E9aeEAd79Df`](https://evm.flowscan.io/address/0xe7c2B80a9de81340AE375B3a53940E9aeEAd79Df)|
+| Contracts                             | Testnet                                                                                                                            | Mainnet                                                                                                                    |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `FlowEVMBridgeFactory.sol`            | [`0xf8146b4aef631853f0eb98dbe28706d029e52c52`](https://evm-testnet.flowscan.io/address/0xF8146B4aEF631853F0eB98DBE28706d029e52c52) | [`0x1c6dea788ee774cf15bcd3d7a07ede892ef0be40`](https://evm.flowscan.io/address/0x1C6dEa788Ee774CF15bCd3d7A07ede892ef0bE40) |
+| `FlowEVMBridgeDeploymentRegistry.sol` | [`0x8781d15904d7e161f421400571dea24cc0db6938`](https://evm-testnet.flowscan.io/address/0x8781d15904d7e161f421400571dea24cc0db6938) | [`0x8fdec2058535a2cb25c2f8cec65e8e0d0691f7b0`](https://evm.flowscan.io/address/0x8FDEc2058535A2Cb25C2f8ceC65e8e0D0691f7B0) |
+| `FlowEVMBridgedERC20Deployer.sol`     | [`0x4d45CaD104A71D19991DE3489ddC5C7B284cf263`](https://evm-testnet.flowscan.io/address/0x4d45CaD104A71D19991DE3489ddC5C7B284cf263) | [`0x49631Eac7e67c417D036a4d114AD9359c93491e7`](https://evm.flowscan.io/address/0x49631Eac7e67c417D036a4d114AD9359c93491e7) |
+| `FlowEVMBridgedERC721Deployer.sol`    | [`0x1B852d242F9c4C4E9Bb91115276f659D1D1f7c56`](https://evm-testnet.flowscan.io/address/0x1B852d242F9c4C4E9Bb91115276f659D1D1f7c56) | [`0xe7c2B80a9de81340AE375B3a53940E9aeEAd79Df`](https://evm.flowscan.io/address/0xe7c2B80a9de81340AE375B3a53940E9aeEAd79Df) |
 
 And below are the bridge escrow's EVM addresses. These addresses are [`CadenceOwnedAccount`s (COA)](https://developers.flow.com/tutorials/cross-vm-apps/interacting-with-coa#coa-interface) and they are stored stored in the same Flow account as you'll find the Cadence contracts (see above).
 
-|Network|Address|
-|---|---|
-|Testnet|[`0x0000000000000000000000023f946ffbc8829bfd`](https://evm-testnet.flowscan.io/address/0x0000000000000000000000023f946FFbc8829BFD)|
-|Mainnet|[`0x00000000000000000000000249250a5c27ecab3b`](https://evm.flowscan.io/address/0x00000000000000000000000249250a5C27Ecab3B)|
+| Network | Address                                                                                                                            |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Testnet | [`0x0000000000000000000000023f946ffbc8829bfd`](https://evm-testnet.flowscan.io/address/0x0000000000000000000000023f946FFbc8829BFD) |
+| Mainnet | [`0x00000000000000000000000249250a5c27ecab3b`](https://evm.flowscan.io/address/0x00000000000000000000000249250a5C27Ecab3B)         |


### PR DESCRIPTION
Somehow, an old link is present in the bridge contract doc that didn't break the build previously.