### PR TITLE
Add AI Setup Video

### DIFF
--- a/docs/tutorials/ai-plus-flow/chatgpt/index.md
+++ b/docs/tutorials/ai-plus-flow/chatgpt/index.md
@@ -22,6 +22,17 @@ keywords:
 
 This guide walks you through creating a **Custom GPT** using ChatGPT that can reference the [Flow Data Sources] file to answer questions.
 
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%' }}>
+  <iframe 
+    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+    src="https://www.youtube.com/embed/Lu6KrNvGthI" 
+    title="YouTube video player" 
+    frameborder="0" 
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+    allowfullscreen
+  ></iframe>
+</div>
+
 :::warning
 
 You'll need a [ChatGPT Plus subscription] to use the **Custom GPT** feature.

--- a/docs/tutorials/ai-plus-flow/cursor/index.md
+++ b/docs/tutorials/ai-plus-flow/cursor/index.md
@@ -19,6 +19,17 @@ keywords:
 
 [Cursor] is an AI code editor that makes it easy to write code while building Flow apps. Let's walk through how to setup Cursor for the best possible experience when writing applications on Flow.
 
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%' }}>
+  <iframe 
+    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+    src="https://www.youtube.com/embed/Lu6KrNvGthI" 
+    title="YouTube video player" 
+    frameborder="0" 
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+    allowfullscreen
+  ></iframe>
+</div>
+
 ## Installation
 
 Adding Flow docs lets you interact with our docs directly and get the most accurate answers to your questions.


### PR DESCRIPTION
I've added the same video to both the Cursor and ChatGPT tutorials because it covers both.  The index page isn't appropriate because it has more content that isn't related to the video.