### PR TITLE
Fix Typographical Errors in Documentation

### DIFF
--- a/docs/networks/staking/02-epoch-terminology.md
+++ b/docs/networks/staking/02-epoch-terminology.md
@@ -89,7 +89,7 @@ This phase is expected to take less than 10% of the time of an epoch, near the e
 
 **Cluster Quorum Certificate Generation (QC):** A process by which nodes using the HotStuff consensus algorithm
 submit signed messages in order to generate a certificate for bootstrapping HotStuff. Each collector cluster runs
-a mini-version of HotStuff, and since clusters are randomized each epoch, a new quorum ceritificate is required
+a mini-version of HotStuff, and since clusters are randomized each epoch, a new quorum certificate is required
 for each cluster each epoch.
 
 **Distributed Key Generation (DKG):** Process for generating a shared public key to initialize the random beacon.

--- a/docs/networks/staking/06-technical-overview.md
+++ b/docs/networks/staking/06-technical-overview.md
@@ -115,7 +115,7 @@ This also returns a special node operator object that is stored in the node oper
 This object is used for staking, unstaking, and withdrawing rewards.
 
 Consensus and Collection nodes also need to create a separate machine account
-for use in the DKG and QC proccesses, respectively. This machine account creation
+for use in the DKG and QC processes, respectively. This machine account creation
 is handled automatically by the staking collection smart contract.
 More information is in the [machine account documentation](./11-machine-account.md#creation).
 

--- a/docs/networks/staking/14-staking-collection.md
+++ b/docs/networks/staking/14-staking-collection.md
@@ -262,7 +262,7 @@ transaction with the following arguments:
 | **amount**              | `UFix64`           | The number of FLOW tokens to restake. |
 
 <Callout type="info">
-To stake unstaked tokens for an active node, leave the <b>delegatorID</b> arguement as <b>nil</b>.
+To stake unstaked tokens for an active node, leave the <b>delegatorID</b> argument as <b>nil</b>.
 
 If staking for a delegator, <b>delegatorID</b> should be the delegator ID you are staking for.
 </Callout>
@@ -282,7 +282,7 @@ transaction with the following arguments:
 | **amount**              | `UFix64`           | The number of FLOW tokens to restake. |
 
 <Callout type="info">
-To stake rewarded tokens for an active node, leave the <b>delegatorID</b> arguement as <b>nil</b>.
+To stake rewarded tokens for an active node, leave the <b>delegatorID</b> argument as <b>nil</b>.
 </Callout>
 
 ### Request to Unstake Tokens at the end of the Epoch
@@ -304,7 +304,7 @@ transaction with the following arguments:
 | **amount**              | `UFix64`           | The number of FLOW tokens to restake. |
 
 <Callout type="info">
-To unstake tokens from an active node, leave the <b>delegatorID</b> arguement as <b>nil</b>.
+To unstake tokens from an active node, leave the <b>delegatorID</b> argument as <b>nil</b>.
 </Callout>
 
 ### Unstake All Tokens
@@ -332,7 +332,7 @@ transaction with the following arguments:
 | **amount**              | `UFix64`           | The number of FLOW tokens to withdraw. |
 
 <Callout type="info">
-To withdraw unstaked tokens from an active node, leave the <b>delegatorID</b> arguement as <b>nil</b>.
+To withdraw unstaked tokens from an active node, leave the <b>delegatorID</b> argument as <b>nil</b>.
 </Callout>
 
 ### Withdraw Rewarded Tokens
@@ -349,7 +349,7 @@ transaction with the following arguments:
 | **amount**              | `UFix64`           | The number of FLOW tokens to withdraw. |
 
 <Callout type="info">
-To withdraw rewarded tokens from an active node, leave the <b>delegatorID</b> arguement as <b>nil</b>.
+To withdraw rewarded tokens from an active node, leave the <b>delegatorID</b> argument as <b>nil</b>.
 </Callout>
 
 ## Staking Collection Modification
@@ -374,7 +374,7 @@ transaction with the following arguments:
 | **delegatorID**         | `Optional(UInt32)` | `nil` if staking for a node. If staking for a delegator, the delegator ID. |
 
 <Callout type="info">
-To close an active node, leave the <b>delegatorID</b> arguement as <b>nil</b>.
+To close an active node, leave the <b>delegatorID</b> argument as <b>nil</b>.
 </Callout>
 
 ### Transfer a Node
@@ -543,7 +543,7 @@ can use the **Get Does Node Exist** ([SCO.21](../../build/core-contracts/11-stak
 This script returns a `Bool`.
 
 <Callout type="info">
-To query if a Node is managed by an accounts Staking Collection, leave the <b>delegatorID</b> arguement as <b>nil</b>. 
+To query if a Node is managed by an accounts Staking Collection, leave the <b>delegatorID</b> argument as <b>nil</b>. 
 Otherwise, fill it in with the <b>delegatorID</b> of the Delegator.
 </Callout>
 


### PR DESCRIPTION


**Description:**

This pull request addresses several typographical errors in the documentation files. The changes include:

1. **docs/networks/staking/02-epoch-terminology.md**
   - Corrected "ceritficate" to "certificate".

2. **docs/networks/staking/06-technical-overview.md**
   - Corrected "proccesses" to "processes" for consistency.

3. **docs/networks/staking/14-staking-collection.md**
   - Corrected "arguement" to "argument" in multiple instances.

These changes improve the clarity and professionalism of the documentation.
