### PR TITLE
Fix typos and improve terminology in Flow documentation

### DIFF
--- a/docs/tools/clients/fcl-js/api.md
+++ b/docs/tools/clients/fcl-js/api.md
@@ -2125,4 +2125,4 @@ Signature objects are used to represent a signature for a particular message as 
 | ----------- | ------------------- | -------------------------------------------------------------------------------------------- |
 | `addr`      | [Address](#address) | the address of the account which this signature has been generated for                       |
 | `keyId`     | number              | The index of the key to use during authorization. (Multiple keys on an account is possible). |
-| `signature` | string              | a hexidecimal-encoded string representation of the generated signature                       |
+| `signature` | string              | a hexadecimal-encoded string representation of the generated signature                       |

--- a/docs/tools/clients/fcl-js/sdk-guidelines.md
+++ b/docs/tools/clients/fcl-js/sdk-guidelines.md
@@ -342,7 +342,7 @@ Flow supports great flexibility when it comes to transaction signing, we can def
 | `0x01`  | 1      | 1000   |
 
 ```javascript
-// There are multiple ways to acheive this
+// There are multiple ways to achieve this
 import * as fcl from "@onflow/fcl"
 
 // FCL provides currentUser as an authorization function

--- a/docs/tools/clients/flow-go-sdk/index.md
+++ b/docs/tools/clients/flow-go-sdk/index.md
@@ -1078,7 +1078,7 @@ publicKey := privateKey.PublicKey()
 
 The example above uses an ECDSA key pair on the P-256 (secp256r1) elliptic curve. Flow also supports the secp256k1 curve used by Bitcoin and Ethereum. Read more about [supported algorithms here](../../../build/basics/accounts.md#signature-and-hash-algorithms).
 
-### Transfering Flow
+### Transferring Flow
 
 This is an example of how to construct a FLOW token transfer transaction
 with the Flow Go SDK.

--- a/docs/tools/wallet-provider-spec/custodial.md
+++ b/docs/tools/wallet-provider-spec/custodial.md
@@ -259,7 +259,7 @@ Below is the public authorization hook we received during the challenge above.
   }
 ```
 
-FCL will take that hook and do the following post requeset:
+FCL will take that hook and do the following post request:
 
 ```
 POST https://provider.com/flow/authorize


### PR DESCRIPTION


**Description:** 
This PR addresses several minor issues in the Flow documentation:
- Corrects the spelling of "hexadecimal" in fcl-js API docs
- Fixes typo "acheive" to "achieve" in SDK guidelines
- Corrects "Transfering" to "Transferring" in Go SDK docs
- Fixes typo "requeset" to "request" in wallet provider spec

These changes improve readability and consistency across the documentation.
