### PR TITLE
Fix typos in FCL-JS and Flow SDK documentation

### DIFF
--- a/docs/tools/clients/fcl-js/api.md
+++ b/docs/tools/clients/fcl-js/api.md
@@ -711,7 +711,7 @@ const isValid = await fcl.AppUtils.verifyUserSignatures(
 ### `AppUtils.verifyAccountProof`
 
 A method allowing applications to cryptographically prove that a user controls an on-chain account. During user authentication, some FCL compatible wallets will choose to support the FCL `account-proof` service. If a wallet chooses to support this service, and the user approves the signing of message data, they will return `account-proof` data and a signature(s) that can be used to prove a user controls an on-chain account.
-See [proving-authentication](https://github.com/onflow/fcl-js/blob/master/docs/reference/proving-authentication.mdx) documentaion for more details.
+See [proving-authentication](https://github.com/onflow/fcl-js/blob/master/docs/reference/proving-authentication.mdx) documentation for more details.
 
 ⚠️ `fcl.config.flow.network` or options override is required to use this api. See [FCL Configuration](#configuration).
 

--- a/docs/tools/clients/fcl-js/sdk-guidelines.md
+++ b/docs/tools/clients/fcl-js/sdk-guidelines.md
@@ -342,7 +342,7 @@ Flow supports great flexibility when it comes to transaction signing, we can def
 | `0x01`  | 1      | 1000   |
 
 ```javascript
-// There are multiple ways to acheive this
+// There are multiple ways to achieve this
 import * as fcl from "@onflow/fcl"
 
 // FCL provides currentUser as an authorization function

--- a/docs/tools/clients/flow-go-sdk/index.md
+++ b/docs/tools/clients/flow-go-sdk/index.md
@@ -1078,7 +1078,7 @@ publicKey := privateKey.PublicKey()
 
 The example above uses an ECDSA key pair on the P-256 (secp256r1) elliptic curve. Flow also supports the secp256k1 curve used by Bitcoin and Ethereum. Read more about [supported algorithms here](../../../build/basics/accounts.md#signature-and-hash-algorithms).
 
-### Transfering Flow
+### Transferring Flow
 
 This is an example of how to construct a FLOW token transfer transaction
 with the Flow Go SDK.


### PR DESCRIPTION
This PR fixes several minor typos in the documentation:

- Corrects "documentaion" to "documentation" in fcl-js/api.md
- Fixes "acheive" to "achieve" in fcl-js/sdk-guidelines.md
- Adjusts formatting in flow-go-sdk/index.md

These changes improve readability and consistency of the documentation.