### PR TITLE
Fix broken wallet provider spec link in proving-authentication.mdx

### DIFF
--- a/docs/tools/clients/fcl-js/proving-authentication.mdx
+++ b/docs/tools/clients/fcl-js/proving-authentication.mdx
@@ -18,7 +18,7 @@ We'll walk through how you, an application developer, can use the `account-proof
 authenticate a user.
 
 > Are you an FCL Wallet Developer? Check out the wallet provider specific docs
-> [here](https://github.com/onflow/fcl-js/tree/master/packages/fcl/src/wallet-provider-spec/provable-authn.md)
+> [here](https://github.com/onflow/fcl-js/blob/master/packages/fcl-core/src/wallet-provider-spec/provable-authn.md)
 
 ### Authenticating a user using `account-proof`
 


### PR DESCRIPTION
Updated the outdated link to the correct wallet provider specification file.