### PR TITLE
docs: Update network name to "Flow EVM Mainnet" in documentation

### DIFF
--- a/docs/evm/networks.md
+++ b/docs/evm/networks.md
@@ -12,7 +12,7 @@ Flow EVM has the following public RPC nodes available:
 
 | Name            | Value                                |
 | --------------- | ------------------------------------ |
-| Network Name    | Flow EVM                             |
+| Network Name    | Flow EVM Mainnet                     |
 | Description     | The public RPC URL for Flow Mainnet  |
 | RPC Endpoint    | https://mainnet.evm.nodes.onflow.org |
 | Chain ID        | 747                                  |

--- a/docs/evm/using.mdx
+++ b/docs/evm/using.mdx
@@ -31,7 +31,7 @@ Manual method: Add Flow EVM as a custom network to MetaMask:
 
 | Name            | Value                                |
 | --------------- | ------------------------------------ |
-| Network Name    | Flow EVM                             |
+| Network Name    | Flow EVM Mainnet                     |
 | Description     | The public RPC url for Flow Mainnet  |
 | RPC Endpoint    | https://mainnet.evm.nodes.onflow.org |
 | Chain ID        | 747                                  |


### PR DESCRIPTION
Change network name from "Flow EVM" to "Flow EVM Mainnet" to keep name's consistency with https://chainlist.org/?search=Flow