### PR TITLE
Update onflow.org to flow.com except for infra

### DIFF
--- a/docs/build/advanced-concepts/metadata-views.md
+++ b/docs/build/advanced-concepts/metadata-views.md
@@ -19,25 +19,26 @@ sidebar_label: NFT Metadata Views
 
 # NFT Metadata Views on Flow
 
-`MetadataViews` on Flow offer a standardized way to represent onchain metadata 
+`MetadataViews` on Flow offer a standardized way to represent onchain metadata
 across different NFTs. Through its integration, developers can ensure
 that different platforms and marketplaces can interpret the NFT metadata
 in a unified manner. This means that when users visit different websites,
-wallets, and marketplaces, 
+wallets, and marketplaces,
 the NFT metadata will be presented in a consistent manner,
 ensuring a uniform experience across various platforms.
 
 :::info
 
-It is important to understand this document so you can make meaningful decisions 
+It is important to understand this document so you can make meaningful decisions
 about how to manage your project's metadata as support for metadata views does
 not happen by default. Each project has unique metadata and therefore will have to
 define how they expose it in unique ways.
 
 :::
 
-A view is a standard Cadence struct that represents a specific type of metadata, 
+A view is a standard Cadence struct that represents a specific type of metadata,
 such as a [Royalty specification](https://github.com/onflow/flow-nft?tab=readme-ov-file#royalty-view):
+
 ```cadence
 access(all) struct Royalty {
     /// Where royalties should be paid to
@@ -52,6 +53,7 @@ access(all) struct Royalty {
 ```
 
 or a [rarity description](https://github.com/onflow/flow-nft/blob/master/contracts/MetadataViews.cdc#L614):
+
 ```cadence
 access(all) struct Rarity {
     /// The score of the rarity as a number
@@ -72,11 +74,11 @@ the content of this document so third party apps can integrate with their
 smart contracts as easily and effectively as possible.
 
 > If you'd like to follow along while we discuss the concepts below,
-you can do so by referring to 
-the [ExampleNFT contract](https://github.com/onflow/flow-nft/blob/master/contracts/ExampleNFT.cdc).
-Additionally, here is the source code for the
-[`ViewResolver` contract](https://github.com/onflow/flow-nft/blob/master/contracts/ViewResolver.cdc)
-and the [`MetadataViews` contract](https://github.com/onflow/flow-nft/blob/master/contracts/MetadataViews.cdc).
+> you can do so by referring to
+> the [ExampleNFT contract](https://github.com/onflow/flow-nft/blob/master/contracts/ExampleNFT.cdc).
+> Additionally, here is the source code for the
+> [`ViewResolver` contract](https://github.com/onflow/flow-nft/blob/master/contracts/ViewResolver.cdc)
+> and the [`MetadataViews` contract](https://github.com/onflow/flow-nft/blob/master/contracts/MetadataViews.cdc).
 
 Flowty has also provided [a useful guide](https://docs.flowty.io/developer-docs/)
 for how to manage metadata views properly
@@ -89,12 +91,12 @@ regardless of what marketplace it is using.
 Metadata in Cadence is structured at two distinct levels:
 
 1. **Contract-Level Metadata**: This provides an overarching description
-of the entire NFT collection/project. 
-Any metadata about individual NFTs is not included here.
+   of the entire NFT collection/project.
+   Any metadata about individual NFTs is not included here.
 
-2. **NFT-Level Metadata**: Diving deeper, this metadata relates to individual NFTs. 
-It provides context, describes rarity, and highlights other distinctive attributes
-that distinguish one NFT from another within the same collection.
+2. **NFT-Level Metadata**: Diving deeper, this metadata relates to individual NFTs.
+   It provides context, describes rarity, and highlights other distinctive attributes
+   that distinguish one NFT from another within the same collection.
 
 While these distinct levels describe different aspects of a project,
 they both use the same view system for representing the metadata
@@ -105,21 +107,21 @@ just from different places.
 
 When considering Flow and how it handles metadata for NFTs,
 it is crucial to understand two essential interfaces:
-`ViewResolver` and `MetadataViews.Resolver`. 
-[Interfaces](https://cadence-lang.org/docs/language/interfaces) 
+`ViewResolver` and `MetadataViews.Resolver`.
+[Interfaces](https://cadence-lang.org/docs/language/interfaces)
 serve as blueprints for types that specify the required fields and methods
-that your contract or [composite type](https://cadence-lang.org/docs/language/composite-types) must adhere to 
+that your contract or [composite type](https://cadence-lang.org/docs/language/composite-types) must adhere to
 to be considered a subtype of that interface.
 This guarantees that any contract asserting adherence to these interfaces
 will possess a consistent set of functionalities
 that other applications or contracts can rely on.
 
 1. **`ViewResolver` for Contract-Level Metadata**:
-    - This interface ensures that **contracts**, particularly those encapsulating NFT collections, conform to the Metadata Views standard.
-    - Through the adoption of this interface, contracts can provide dynamic metadata that represents the entirety of the collection.
+   - This interface ensures that **contracts**, particularly those encapsulating NFT collections, conform to the Metadata Views standard.
+   - Through the adoption of this interface, contracts can provide dynamic metadata that represents the entirety of the collection.
 2. **`MetadataViews.Resolver` (`ViewResolver.Resolver` in Cadence 1.0) for NFT-Level Metadata**:
-    - Used within **individual NFT resources**, this interface ensures each token adheres to the Metadata standard format.
-    - It focuses on the distinct attributes of an individual NFT, such as its unique ID, name, description, and other defining characteristics.
+   - Used within **individual NFT resources**, this interface ensures each token adheres to the Metadata standard format.
+   - It focuses on the distinct attributes of an individual NFT, such as its unique ID, name, description, and other defining characteristics.
 
 ### Core Functions
 
@@ -164,7 +166,6 @@ As you can see, the return values of `getViews()` can be used as arguments
 for `resolveView()` if you want to just iterate through all the views
 that an NFT implements.
 
-
 ## NFT-Level Metadata Implementation
 
 NFT-level metadata addresses the unique attributes of individual tokens
@@ -200,12 +201,13 @@ access(all) resource NFT: NonFungibleToken.NFT {
 
 To make this possible though, it is **vital** that projects
 all use the standard metadata views in the same way, so third-party
-applications can consume them in standard ways. 
+applications can consume them in standard ways.
 
 For example, many metadata views have `String`-typed fields. It is difficult
 to enforce that these fields are formatted in the correct way, so it is important
 for projects to be dilligent about how they use them. Take `Traits` for example,
 a commonly misused metadata view:
+
 ```cadence
 access(all) struct Trait {
     // The name of the trait. Like Background, Eyes, Hair, etc.
@@ -214,6 +216,7 @@ access(all) struct Trait {
     ...
 }
 ```
+
 The name of the trait should be formatted in a way so that it is easy to display
 on a user-facing website. Many projects will use something like CamelCase for
 the value, so it looks like "HairColor", which is not pretty on a website.
@@ -246,13 +249,16 @@ case Type<MetadataViews.Display>():
         )
     )
 ```
+
 If the thumbnail is a HTTP resource:
-```cadence 
+
+```cadence
 thumbnail : MetadataViews.HTTPFile(url: *Please put your url here)
 ```
 
 If the thumbnail is an IPFS resource:
-```cadence 
+
+```cadence
 //
 thumbnail : MetadataViews.IPFSFile(
 	cid: thumbnail cid, // Type <String>
@@ -260,12 +266,13 @@ thumbnail : MetadataViews.IPFSFile(
 )
 ```
 
-![MetadataViews.Display](display.png "Display")
+![MetadataViews.Display](display.png 'Display')
 
 :::info
 
 Note about SVG files on-chain: SVG field should be sent as `thumbnailURL`,
 should be base64 encoded, and should have a dataURI prefix, like so:
+
 ```
 data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMSIgaGVpZ2h0PSIxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InJlZCIvPjwvc3ZnPg==
 ```
@@ -323,6 +330,7 @@ including the percentage of sales revenue that will go to the original creator
 or other stakeholders on secondary sales.
 
 Each royalty view contains a fungible token receiver capability where royalties should be paid:
+
 ```cadence
 access(all) struct Royalty {
 
@@ -333,6 +341,7 @@ access(all) struct Royalty {
 ```
 
 here is an example of how an NFT might return a `Royalties` view:
+
 ```cadence
 case Type<MetadataViews.Royalties>():
     // Assuming each 'Royalty' in the 'royalties' array has 'cut' and 'description' fields
@@ -342,7 +351,7 @@ case Type<MetadataViews.Royalties>():
             receiver: ExampleNFT.account.capabilities.get<&AnyResource{FungibleToken.Receiver}>(/public/GenericFTReceiver),
             // The percentage cut of each sale
             cut: 0.05,
-            // A description of the royalty terms          
+            // A description of the royalty terms
             description: "Royalty payment to the original creator"
         )
     }
@@ -354,10 +363,11 @@ the marketplace can check to see if the royalty receiver
 accepts the seller's desired fungible token by calling
 the `receiver.getSupportedVaultTypes(): {Type: Bool}`
 function via the `receiver` reference:
+
 ```cadence
 let royaltyReceiverRef = royalty.receiver.borrow()
     ?? panic("Could not borrow a reference to the receiver")
-let supportedTypes = receiverRef.getSupportedVaultTypes() 
+let supportedTypes = receiverRef.getSupportedVaultTypes()
 if supportedTypes[**royalty.getType()**] {
     // The type is supported, so you can deposit
     recieverRef.deposit(<-royalty)
@@ -382,10 +392,10 @@ to the correct vault in the receiving account.
 #### Important instructions for royalty receivers
 
 If you plan to set your account as a receiver of royalties,
-you'll likely want to be able to accept as many token types as possible. 
+you'll likely want to be able to accept as many token types as possible.
 This is possible with the `FungibleTokenSwitchboard`.
 If you initialize a switchboard in your account, it can accept any generic fungible token
-and route it to the correct vault in your account. 
+and route it to the correct vault in your account.
 
 Therefore, if you want to receive royalties, you should set up your account with the
 [`setup_royalty_account_by_paths.cdc`](https://github.com/onflow/flow-ft/blob/master/transactions/switchboard/setup_royalty_account_by_paths.cdc) transaction.
@@ -403,13 +413,14 @@ that uses a URL.
 
 ```cadence
 case Type<MetadataViews.ExternalURL>():
-    return MetadataViews.ExternalURL("<https://example-nft.onflow.org/>".concat(self.id.toString()))
+    return MetadataViews.ExternalURL("<https://example-nft.flow.com/>".concat(self.id.toString()))
 ```
 
 ### Traits Metadata
 
 The [`Trait`](https://github.com/onflow/flow-nft/blob/master/contracts/MetadataViews.cdc#L655) view type encapsulates the unique attributes of an NFT, like any visual aspects or category-defining properties. These can be essential for marketplaces that need to sort or filter NFTs based on these characteristics.
 By returning trait views as recommended, you can fit the data in the places you want.
+
 ```cadence
 access(all) struct Trait {
         // The name of the trait. Like Background, Eyes, Hair, etc.
@@ -440,7 +451,7 @@ how to display the trait properly. Developers should not just default
 to `String` or `Integer` for all their display types.
 When applicable, the display types to accurately reflect the data that needs to be displayed.
 
-![MetadataViews.Traits](traits_String.png "traits_String")
+![MetadataViews.Traits](traits_String.png 'traits_String')
 
 #### Note: Always prefer wrappers over single views
 
@@ -476,6 +487,7 @@ at the collection or series level rather than individual NFTs.
 These views should still should be queryable via individual NFTs though.
 One can accomplish this by just forwarding the call
 from the NFT's `resolveView()` method to the contract's `resolveView()` method, like so:
+
 ```cadence
 /// this line is in `ExampleNFT.NFT.resolveView()`
 case Type<MetadataViews.NFTCollectionDisplay>():
@@ -530,7 +542,7 @@ case Type<MetadataViews.NFTCollectionDisplay>():
     return MetadataViews.NFTCollectionDisplay(
         name: "The Example Collection",
         description: "This collection is used as an example to help you develop your next Flow NFT.",
-        externalURL: MetadataViews.ExternalURL("<https://example-nft.onflow.org>"),
+        externalURL: MetadataViews.ExternalURL("<https://example-nft.flow.com>"),
         squareImage: media,
         bannerImage: media,
         socials: {
@@ -544,11 +556,11 @@ like the collection's name and description but also provides image URLs
 for visual representations of the collection (`squareImage` and `bannerImage`)
 and external links, including social media profiles.
 
-![MetadataViews.CollectionDisplay](collectionDisplay.png "CollectionDisplay")
+![MetadataViews.CollectionDisplay](collectionDisplay.png 'CollectionDisplay')
 
 ### Contract-borrowing Metadata
 
-With the contract borrowing feature, the [ViewResolver](https://github.com/onflow/flow-nft/blob/master/contracts/ViewResolver.cdc) 
+With the contract borrowing feature, the [ViewResolver](https://github.com/onflow/flow-nft/blob/master/contracts/ViewResolver.cdc)
 interface on contracts can be borrowed directly without needing to import the contract first.
 Views can be resolved directly from there.
 As an example, you might want to allow your contract
@@ -575,6 +587,7 @@ access(all) fun main(addr: Address, name: String): StoragePath? {
 ```
 
 Will Return
+
 ```cadence
 {"domain":"storage","identifier":"exampleNFTCollection"}
 ```
@@ -586,7 +599,7 @@ is crucial for developers aiming to deploy NFTs on Flow.
 With these views and functions, NFTs can maintain a consistent presentation
 across various platforms and marketplaces and foster interoperability
 between contracts and applications in the Flow ecosystem.
-To gain a deeper understanding of implementing the MetadataView standard, 
+To gain a deeper understanding of implementing the MetadataView standard,
 check out our documentation on "How to Create an NFT Project on Flow".
 It provides an introduction to integrating these standards into your NFT contracts.
 

--- a/docs/build/advanced-concepts/scaling.md
+++ b/docs/build/advanced-concepts/scaling.md
@@ -22,24 +22,24 @@ Flow is designed for consumer-scale internet applications and is one of the fast
 
 1. **User Transactions**
 
-    These are transactions initiated by users, such as:
+   These are transactions initiated by users, such as:
 
-    * Buying or selling NFTs
-    * Transferring tokens
-    * Swapping tokens on decentralized exchanges (DEXs)
-    * Staking or unstaking tokens
+   - Buying or selling NFTs
+   - Transferring tokens
+   - Swapping tokens on decentralized exchanges (DEXs)
+   - Staking or unstaking tokens
 
-    In this category, each transaction originates from a unique account and is sent to the Flow network from a different machine. Developers don't need to take special measures to scale for this category, beyond ensuring their logic is primarily on-chain and their supporting systems (e.g., frontend, backend) can handle scaling if they become bottlenecks. Flow's protocol inherently manages scaling for user transactions.
+   In this category, each transaction originates from a unique account and is sent to the Flow network from a different machine. Developers don't need to take special measures to scale for this category, beyond ensuring their logic is primarily on-chain and their supporting systems (e.g., frontend, backend) can handle scaling if they become bottlenecks. Flow's protocol inherently manages scaling for user transactions.
 
 2. **System Transactions**
 
-    These are transactions initiated by an app's backend or various tools, such as:
+   These are transactions initiated by an app's backend or various tools, such as:
 
-    * Minting thousands of tokens from a single minter account
-    * Creating transaction workers for custodians
-    * Running maintenance jobs and batch operations
+   - Minting thousands of tokens from a single minter account
+   - Creating transaction workers for custodians
+   - Running maintenance jobs and batch operations
 
-    In this category, many transactions originate from the same account and are sent to the Flow network from the same machine, which can make scaling tricky. This guide focuses on strategies for scaling transactions from a single account.
+   In this category, many transactions originate from the same account and are sent to the Flow network from the same machine, which can make scaling tricky. This guide focuses on strategies for scaling transactions from a single account.
 
 In the following sections, we'll explore how to execute concurrent transactions from a single account on Flow using multiple proposer keys.
 
@@ -56,24 +56,26 @@ Blockchains use sequence numbers, also known as nonces, for each transaction to 
 This behavior presents a challenge for scaling, as sending multiple transactions does not guarantee that they will be executed in the order they were sent. This is a fundamental aspect of Flow's resistance to MEV (Maximal Extractable Value), as transaction ordering is randomized within each block.
 
 If a transaction arrives out of order, the network will reject it and return an error message similar to the following:
+
 ```
 * checking sequence number failed: [Error Code: 1007] invalid proposal key: public key X on account 123 has sequence number 7, but given 6
 ```
+
 Our objective is to execute multiple concurrent transactions without encountering the sequence number error described above. While designing a solution, we must consider the following key factors:
 
 - **Reliability**
 
-    Ideally, we want to avoid local sequence number management, as it is error-prone. In a local sequence number implementation, the sender must determine which error types increment the sequence number and which do not. For instance, network issues do not increment the sequence number, but application errors do. Furthermore, if the sender's sequence number becomes unsynchronized with the network, multiple transactions may fail.
+  Ideally, we want to avoid local sequence number management, as it is error-prone. In a local sequence number implementation, the sender must determine which error types increment the sequence number and which do not. For instance, network issues do not increment the sequence number, but application errors do. Furthermore, if the sender's sequence number becomes unsynchronized with the network, multiple transactions may fail.
 
-    The most reliable approach to managing sequence numbers is to query the network for the latest sequence number before signing and sending each transaction.
+  The most reliable approach to managing sequence numbers is to query the network for the latest sequence number before signing and sending each transaction.
 
 - **Scalability**
 
-    Allowing multiple workers to manage the same sequence number can introduce coupling and synchronization challenges. To address this, we aim to decouple workers so that they can operate independently without interfering with one another.
+  Allowing multiple workers to manage the same sequence number can introduce coupling and synchronization challenges. To address this, we aim to decouple workers so that they can operate independently without interfering with one another.
 
 - **Capacity Management**
 
-    To ensure reliability, the system must recognize when it has reached capacity. Additional transactions should be queued and executed once there is sufficient throughput. Fire-and-forget strategies are unreliable for handling arbitrary traffic, as they do not account for system capacity.
+  To ensure reliability, the system must recognize when it has reached capacity. Additional transactions should be queued and executed once there is sufficient throughput. Fire-and-forget strategies are unreliable for handling arbitrary traffic, as they do not account for system capacity.
 
 ## Solution
 
@@ -83,25 +85,25 @@ We can leverage this model to design an ideal system transaction architecture as
 
 - **Multiple Proposer Keys**
 
-    Flow accounts can have multiple keys. By assigning a unique proposer key to each worker, each worker can independently manage its own sequence number without interference from others.
+  Flow accounts can have multiple keys. By assigning a unique proposer key to each worker, each worker can independently manage its own sequence number without interference from others.
 
 - **Sequence Number Management**
 
-    Each worker ensures it uses the correct sequence number by fetching the latest sequence number from the network. Since workers operate with different proposer keys, there are no conflicts or synchronization issues.
+  Each worker ensures it uses the correct sequence number by fetching the latest sequence number from the network. Since workers operate with different proposer keys, there are no conflicts or synchronization issues.
 
 - **Queue and Processing Workflow**
 
-    * Each worker picks a transaction request from the incoming requests queue, signs it with its assigned proposer key, and submits it to the network.
-    * The worker remains occupied until the transaction is finalized by the network.
-    * If all workers are busy, the incoming requests queue holds additional requests until there is enough capacity to process them.
+  - Each worker picks a transaction request from the incoming requests queue, signs it with its assigned proposer key, and submits it to the network.
+  - The worker remains occupied until the transaction is finalized by the network.
+  - If all workers are busy, the incoming requests queue holds additional requests until there is enough capacity to process them.
 
 - **Key Reuse for Optimization**
 
-    To simplify the system further, we can reuse the same cryptographic key multiple times within the same account by adding it as a new key. These additional keys can have a weight of 0 since they do not need to authorize transactions.
+  To simplify the system further, we can reuse the same cryptographic key multiple times within the same account by adding it as a new key. These additional keys can have a weight of 0 since they do not need to authorize transactions.
 
 Here's a visual example of how such an [account configuration](https://www.flowscan.io/account/18eb4ee6b3c026d2?tab=keys) might look:
 
-![Example.Account](scaling-example-account.png "Example Account")
+![Example.Account](scaling-example-account.png 'Example Account')
 
 As shown, the account includes additional weightless keys designated for proposals, each with its own independent sequence number. This setup ensures that multiple workers can operate concurrently without conflicts or synchronization issues.
 
@@ -142,7 +144,7 @@ We're using Testnet to demonstrate real network conditions. To run this example,
 flow keys generate
 ```
 
-You can use the generated key with the [faucet](https://testnet-faucet.onflow.org/create-account) to create a testnet account. Update the corresponding variables in the `main.go` file:
+You can use the generated key with the [faucet](https://faucet.flow.com/fund-account) to create a testnet account. Update the corresponding variables in the `main.go` file:
 
 ```go
 const PRIVATE_KEY = "123"

--- a/docs/build/basics/fees.md
+++ b/docs/build/basics/fees.md
@@ -42,7 +42,6 @@ Fees will improve the overall security of the network by making malicious action
 
 The unique Flow architecture is targeted at high throughput. It makes it easier to have slack in the system, so short spikes can be handled more gracefully.
 
-
 ### **Fee Structure**
 
 Each transaction fee consists of three components: execution fee, inclusion fee, and network surge factor.
@@ -76,7 +75,7 @@ The inclusion effort of a transaction represents the work needed for:
 - Transporting the transaction information from node to node
 - Verifying transaction signatures
 
-Right now, the inclusion effort is always 1.0 and the inclusion effort cost is fixed to `0.000001`. 
+Right now, the inclusion effort is always 1.0 and the inclusion effort cost is fixed to `0.000001`.
 
 **Surge Factor**
 
@@ -92,7 +91,7 @@ Cost estimation is a two-step process. First, you need to gather the execution e
 
 Flow's approach to storage capacity is a bit similar to some banks' pricing models, where maintaining a minimum balance prevents monthly account fees. Here, the amount of data in your account determines your minimum balance. If you fall below the minimum balance, you cannot transact with your account, except for deposits or deleting data. The essence of storage fee model is that it ensures data availability without continuously charging fees for storage, while also preventing abuses that could burden the network's storage resources. This distinction between current state and blockchain history is crucial for understanding storage requirements and limitations.
 
-Each Flow account has associated storage used. The account's storage used is the byte size of all the data stored in the account's storage. Accounts also have a storage capacity, which is directly tied to the amount of Flow tokens an account has. The account can, without any additional cost, use any amount of storage up to its storage capacity. 
+Each Flow account has associated storage used. The account's storage used is the byte size of all the data stored in the account's storage. Accounts also have a storage capacity, which is directly tied to the amount of Flow tokens an account has. The account can, without any additional cost, use any amount of storage up to its storage capacity.
 
 :::warning
 
@@ -102,7 +101,7 @@ If a transaction puts an account over storage capacity, that transaction fails a
 
 **Storage Capacity**
 
-The storage capacity of an account is dictated by the amount of FLOW it has. 
+The storage capacity of an account is dictated by the amount of FLOW it has.
 
 :::danger
 
@@ -112,11 +111,11 @@ The **minimum amount of FLOW an account can have is 0.001**. This minimum is pro
 
 The minimum account reservation ensures that most accounts won't run out of storage capacity if anyone deposits anything (like an NFT) to the account.
 
-Currently, the amount required to store 100 MB in account storage is 1 Flow. 
+Currently, the amount required to store 100 MB in account storage is 1 Flow.
 
 ![Screenshot 2023-08-17 at 17.27.50.png](_fees_images/Screenshot_2023-08-17_at_17.27.50.png)
 
-Please note that storing data in an account on Flow doesn't charge tokens from the account, it just makes sure you will keep the tokens as a reserve. Once the storage is freed up you can transfer the Flow tokens. 
+Please note that storing data in an account on Flow doesn't charge tokens from the account, it just makes sure you will keep the tokens as a reserve. Once the storage is freed up you can transfer the Flow tokens.
 
 ### Storage Capacity of the Payer
 
@@ -140,7 +139,7 @@ Data stored on the Flow blockchain is stored in a key-value ledger. Each item's 
 
 ### Maximum available balance
 
-Due to the storage restrictions, there is a maximum available balance that user can withdraw from the wallet. The core contract [`FlowStorageFees`](../core-contracts/05-flow-fees.md#flowstoragefees) provides a function to retrieve that value:  
+Due to the storage restrictions, there is a maximum available balance that user can withdraw from the wallet. The core contract [`FlowStorageFees`](../core-contracts/05-flow-fees.md#flowstoragefees) provides a function to retrieve that value:
 
 ```cadence
 import "FlowStorageFees"
@@ -273,7 +272,7 @@ tx := flow.NewTransaction().
 
 ### Maximum transaction fees of a transaction
 
-The maximum possible fee imposed on the payer for a transaction can be calculated as the **inclusion cost plus the execution cost**. The execution cost is the fee calculated for running the transaction based on the [execution effort limit maximum specified](#configuring-execution-limits). 
+The maximum possible fee imposed on the payer for a transaction can be calculated as the **inclusion cost plus the execution cost**. The execution cost is the fee calculated for running the transaction based on the [execution effort limit maximum specified](#configuring-execution-limits).
 
 The payer will never pay more than this amount for the transaction.
 
@@ -400,13 +399,13 @@ There are several places to learn more about transaction fees:
 - [FLIP-753](https://github.com/onflow/flow/pull/753)
 - [Flow Fees Contract](https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowFees.cdc)
 
-> **Note**: If you have thoughts on the implementation of transaction fees on Flow, you can [leave feedback on this forum post](https://forum.onflow.org/t/variable-transaction-fees-are-coming-to-flow/2941).
+> **Note**: If you have thoughts on the implementation of transaction fees on Flow, you can [leave feedback on this forum post](https://forum.flow.com/t/variable-transaction-fees-are-coming-to-flow/2941).
 
 ## FAQs
 
 **When will the fee update go into effect?**
 
-The updates were rolled out with the [Spork on April 6, 2022](../../networks/node-ops/node-operation/past-upgrades#mainnet-17), and were enabled on [June 1st](https://forum.onflow.org/t/permissionless-contract-deployment-progress/2981) during the [weekly epoch transition](https://github.com/onflow/service-account/tree/main/transactions/set-execution-effort-weights/2022/jun-1).
+The updates were rolled out with the [Spork on April 6, 2022](../../networks/node-ops/node-operation/past-upgrades#mainnet-17), and were enabled on [June 1st](https://forum.flow.com/t/permissionless-contract-deployment-progress/2981) during the [weekly epoch transition](https://github.com/onflow/service-account/tree/main/transactions/set-execution-effort-weights/2022/jun-1).
 
 **Why are fees collected even when transactions fail?**
 

--- a/docs/build/basics/flow-token.md
+++ b/docs/build/basics/flow-token.md
@@ -78,7 +78,7 @@ If you have already purchased FLOW and wish to hold it, you have a couple of opt
 
 - For larger, long term holdings - you may want to use a custody provider to keep your funds safe.
 
-You can find wallets and custodians supporting Flow in the [Flow Port](https://port.onflow.org/)
+You can find wallets and custodians supporting Flow in the [Flow Port](https://port.flow.com/)
 
 ### Voting with FLOW
 

--- a/docs/build/flow.md
+++ b/docs/build/flow.md
@@ -24,17 +24,15 @@ keywords:
   - maximum extractable value
 ---
 
-
 # Why Flow
 
+Flow was built by consumer-facing, onchain app developers to solve the problem of building consumer-facing, onchain apps. Dieter Shirley, Chief Architect of Flow and co-author of the [ERC-721 NFT standard] calls it:
 
-Flow was built by consumer-facing, onchain app developers to solve the problem of building consumer-facing, onchain apps.  Dieter Shirley, Chief Architect of Flow and co-author of the [ERC-721 NFT standard] calls it:
-
->**A computer that anyone can use, everyone can trust, and no one can shut down.**
+> **A computer that anyone can use, everyone can trust, and no one can shut down.**
 
 Much of the protocol design is based on lessons learned from building web3 applications while working at [Dapper Labs], particularly [CryptoKitties] - the first onchain game to reach [widespread popularity]. The game went viral, then [struggled under its own success] when it caused so much traffic that Ethereum network itself was overwhelmed by the load.
 
-The design of Flow was guided by the need to alleviate this burden while creating the best experience possible for both developers and users.  The blockchain network of the future must be able to handle millions of users while upholding the key pillars of decentralization:
+The design of Flow was guided by the need to alleviate this burden while creating the best experience possible for both developers and users. The blockchain network of the future must be able to handle millions of users while upholding the key pillars of decentralization:
 
 1. Verifiability
 1. Predictability/Reliability
@@ -47,42 +45,42 @@ Flow solves the [blockchain trilemma] and represents the next generation of bloc
 
 ## What Makes Flow Unique
 
-Flow is a fast, decentralized, and developer-friendly blockchain designed to be the foundation for a new generation of games, apps, and the [digital assets] that power them. It is based on a unique [multi-role architecture], and designed to [scale without sharding], allowing for massive improvements in speed and throughput while preserving a developer-friendly, ACID-compliant environment.  It natively allows development of smart contracts in the powerful [Cadence] language, and also supports full [Ethereum Virtual Machine (EVM)] equivalence with contracts written in Solidity.
+Flow is a fast, decentralized, and developer-friendly blockchain designed to be the foundation for a new generation of games, apps, and the [digital assets] that power them. It is based on a unique [multi-role architecture], and designed to [scale without sharding], allowing for massive improvements in speed and throughput while preserving a developer-friendly, ACID-compliant environment. It natively allows development of smart contracts in the powerful [Cadence] language, and also supports full [Ethereum Virtual Machine (EVM)] equivalence with contracts written in Solidity.
 
 ### Flow Blockchain
 
 - **Multi-role architecture:** The [multi-role architecture] of Flow allows the network to [scale without sharding] to serve billions of users without reducing the decentralization of consensus and verification.
-- **True Fast Finality**: For most other networks, it takes minutes, [a day], or even [a week] to reach hard finality - the point in which a transaction cannot be reversed.  On Flow, the median time for finality is [under 10 seconds], without compromising security.
-- **Native VRF**: Flow provides [onchain randomness] at the protocol level.  Instead of implementing a complex setup and [paying $10+ USD per number], simply call the built-in function.
-- **MEV Resistance**: Flow is designed to [ensure equitable access] by resisting MEV.  Maximum Extractable Value, also know as Miner-Extractable Value (MEV), is a practice common in other blockchains in which the builder of a block can profit at your expense by manipulating where and how your transaction is included.  
+- **True Fast Finality**: For most other networks, it takes minutes, [a day], or even [a week] to reach hard finality - the point in which a transaction cannot be reversed. On Flow, the median time for finality is [under 10 seconds], without compromising security.
+- **Native VRF**: Flow provides [onchain randomness] at the protocol level. Instead of implementing a complex setup and [paying $10+ USD per number], simply call the built-in function.
+- **MEV Resistance**: Flow is designed to [ensure equitable access] by resisting MEV. Maximum Extractable Value, also know as Miner-Extractable Value (MEV), is a practice common in other blockchains in which the builder of a block can profit at your expense by manipulating where and how your transaction is included.
 - **Consumer Onboarding:** Flow was designed for mainstream consumers, with payment onramps catalyzing a safe and low-friction path from fiat to crypto.
-- **EVM Equivalence**: The [Cadence] Virtual Machine (VM) is powerful enough to allow other VMs to run inside of it, almost like a Docker Container.  The first one integrated in this way is [EVM] and the EVM RPC API.
-- **Efficient Gas Costs**: The Flow blockchain is extremely efficient, allowing apps to do more computation at lower costs. 
+- **EVM Equivalence**: The [Cadence] Virtual Machine (VM) is powerful enough to allow other VMs to run inside of it, almost like a Docker Container. The first one integrated in this way is [EVM] and the EVM RPC API.
+- **Efficient Gas Costs**: The Flow blockchain is extremely efficient, allowing apps to do more computation at lower costs.
 
 ### Flow Cadence
 
-- **Native Account Abstraction**: Flow has protocol-native [account abstraction].  All accounts are smart accounts, supporting scripting, multiple keys, multi-signature transactions, and walletless onboarding with social logins.
-- **Gasless Transactions**: Flow has multiple [signing roles] for each transaction.  Most notably, the payer can be set independently of the authorizer.  In other words, having one account sign a transaction and another pay for that transaction is a built-in feature.
-- **Security:** Smart contracts on Flow are natively written in [Cadence], an easier, safer, and more secure programming language for crypto assets and apps.  It's the first high-level, [resource-oriented] programming language.
+- **Native Account Abstraction**: Flow has protocol-native [account abstraction]. All accounts are smart accounts, supporting scripting, multiple keys, multi-signature transactions, and walletless onboarding with social logins.
+- **Gasless Transactions**: Flow has multiple [signing roles] for each transaction. Most notably, the payer can be set independently of the authorizer. In other words, having one account sign a transaction and another pay for that transaction is a built-in feature.
+- **Security:** Smart contracts on Flow are natively written in [Cadence], an easier, safer, and more secure programming language for crypto assets and apps. It's the first high-level, [resource-oriented] programming language.
 - **Developer Ergonomics:** The Flow network is designed to maximize developer productivity. Examples range from upgradeable smart contracts to built-in logging support to the Flow Emulator.
 
 ### Flow EVM
 
-- **Speed, Cost, and Compatibility**: Flow EVM can already run all of your audited Solidity contracts at an average of less than 1 cent per transaction ([usually way less!]).  Unlike L2 solutions, Flow EVM reaches true finality in seconds - not in [a week]. 😳
+- **Speed, Cost, and Compatibility**: Flow EVM can already run all of your audited Solidity contracts at an average of less than 1 cent per transaction ([usually way less!]). Unlike L2 solutions, Flow EVM reaches true finality in seconds - not in [a week]. 😳
 - **Bridge from Other EVM Networks**: You can [bridge] hundreds of assets from dozens of chains to Flow.
 - **VM Token Bridge**: Assets can be bridged between Flow Cadence and Flow EVM easily and atomically with the VM token bridge. Assets can even be bridged **and used** in a **single** transaction, allowing full composability between the EVM and Cadence environments.
-- **Access to Cadence**: Access Cadence features and contracts from Flow EVM to take advantage of native [VRF], higher computation for lower cost, and any asset on Cadence Flow.  You can also build [cross-vm apps] on top of the wagmi/viem/RainbowKit stack, enabling batched transactions and more.
-- **EVM Equivalence:** Flow EVM is truly _EVM Equivalent_, not just _EVM Compatible_.  It runs exactly the same as EVM mainnet, which means builders won't run into "minor" variances or endless "quirks" when they try to integrate.  If it works on Ethereum Mainnet, it will work with Flow EVM.
+- **Access to Cadence**: Access Cadence features and contracts from Flow EVM to take advantage of native [VRF], higher computation for lower cost, and any asset on Cadence Flow. You can also build [cross-vm apps] on top of the wagmi/viem/RainbowKit stack, enabling batched transactions and more.
+- **EVM Equivalence:** Flow EVM is truly _EVM Equivalent_, not just _EVM Compatible_. It runs exactly the same as EVM mainnet, which means builders won't run into "minor" variances or endless "quirks" when they try to integrate. If it works on Ethereum Mainnet, it will work with Flow EVM.
 
 ## Learning Shortcuts
 
-To get a complete picture on how to build on Flow, follow the 👈 sidebar top to bottom.  This path will give you the most thorough onboarding experience.
+To get a complete picture on how to build on Flow, follow the 👈 sidebar top to bottom. This path will give you the most thorough onboarding experience.
 
 If you like to jump right into the deep end of the pool, take a look below for direct links to advanced topics!
 
 ### Learn Cadence
 
-[Cadence] is a modern smart contract programming language designed to work with Flow.  Learning a new language is an investment, but you'll find that Cadence is safer, more explicit, and less dangerous than other blockchain languages.  Plus, it unlocks the full power of the Flow protocol!
+[Cadence] is a modern smart contract programming language designed to work with Flow. Learning a new language is an investment, but you'll find that Cadence is safer, more explicit, and less dangerous than other blockchain languages. Plus, it unlocks the full power of the Flow protocol!
 
 :::tip
 
@@ -115,7 +113,6 @@ The Flow blockchain implements core functionality using its own smart contract l
 - **Staking Table:** The FlowIDTableStaking contract is the central table that manages staked nodes, delegation, and rewards.
 - **Epoch Contract:** The FlowEpoch contract is the state machine that manages Epoch phases and emits service events.
 
-
 ### FLOW Token
 
 The [FLOW] (or $FLOW) token is the native currency for the Flow network. Developers and users can use FLOW to transact on the network. Developers can integrate FLOW directly into their apps for peer-to-peer payments, service charges, or consumer rewards. FLOW can be held, transferred, or transacted peer-to-peer.
@@ -128,7 +125,6 @@ The [FLOW] (or $FLOW) token is the native currency for the Flow network. Develop
 - The [Flow Technical Primer] is a great place to start to understand how Flow works.
 - The [Three technical whitepapers] cover the unique innovation behind the Flow blockchain network in-depth.
 
-
 <!-- Reference-style links, does not render on page -->
 
 [ERC-721 NFT standard]: https://github.com/ethereum/eips/issues/721
@@ -140,13 +136,13 @@ The [FLOW] (or $FLOW) token is the native currency for the Flow network. Develop
 [NFL All Day]: https://nflallday.com/
 [Mattel Creations]: https://creations.mattel.com/pages/virtual
 [Disney Pinnacle]: https://disneypinnacle.com/
-[digital assets]: https://www.onflow.org/post/flow-blockchain-cadence-programming-language-resources-assets
+[digital assets]: https://www.flow.com/post/flow-blockchain-cadence-programming-language-resources-assets
 [widespread popularity]: https://www.cnn.com/style/article/cryptokitty-blockchain/index.html
-[multi-role architecture]: https://www.onflow.org/primer
+[multi-role architecture]: https://www.flow.com/primer
 [onchain randomness]: ./advanced-concepts/randomness.md
 [paying $10+ USD per number]: https://docs.chain.link/vrf/v2-5/billing
 [ensure equitable access]: ./basics/mev-resistance.md
-[scale without sharding]: https://www.onflow.org/post/flow-blockchain-multi-node-architecture-advantages
+[scale without sharding]: https://www.flow.com/post/flow-blockchain-multi-node-architecture-advantages
 [a day]: https://docs.zksync.io/zk-stack/concepts/finality#finality-on-zksync-era
 [a week]: https://docs.optimism.io/stack/rollup/overview#fault-proofs
 [usually way less!]: https://evm.flowscan.io/stats
@@ -163,9 +159,7 @@ The [FLOW] (or $FLOW) token is the native currency for the Flow network. Develop
 [Getting Started]: ./getting-started/contract-interaction.md
 [core contracts]: ./core-contracts/index.md
 [FLOW]: ./core-contracts/03-flow-token.md
-[Flow Technical Primer]: https://www.onflow.org/primer
-[Three technical whitepapers]: https://www.onflow.org/technical-paper
-[Flow Token Economics]: https://www.onflow.org/flow-token-economics
+[Flow Technical Primer]: https://www.flow.com/primer
+[Three technical whitepapers]: https://www.flow.com/technical-paper
+[Flow Token Economics]: https://www.flow.com/flow-token-economics
 [VRF]: ../evm/guides/vrf.md
-
-

--- a/docs/build/guides/account-linking/index.md
+++ b/docs/build/guides/account-linking/index.md
@@ -82,7 +82,7 @@ A link between two existing accounts on Flow can be created in two steps:
 
 These two steps are implemented in Cadence as two transactions:
 
-************************************Create capability************************************
+****************\*\*\*\*****************Create capability****************\*\*\*\*****************
 
 The account B creates and publishes the `&Account` Capability to the account A at the address `0x01`
 
@@ -101,7 +101,7 @@ transaction {
 }
 ```
 
-****************************Claim capability****************************
+************\*\*\*\*************Claim capability************\*\*\*\*************
 
 The account A claims the Capability published by account B.
 
@@ -131,7 +131,7 @@ transaction {
 Account linking was specifically designed to enable smooth and seamless custodial onboarding of users to your Flow based
 application without them first requiring a wallet to do so. This pattern overcomes both the technical hurdle, as well as
 user's reluctance to install a wallet, opening access to Flow applications to every user. Users can experience an app
-without any delay while still offering a path to self-sovreign ownership. 
+without any delay while still offering a path to self-sovreign ownership.
 
 Naturally, users may expect to use their account with another application, or otherwise move assets stored in that
 account elsewhere - at minimum from their wallet. When an app initially leverages account linking, the app creates the
@@ -202,7 +202,7 @@ Learn more about it in the [Hybrid Custody documentation](./parent-accounts.md).
 
 ### Resources
 
-- [Forum Post](https://forum.onflow.org/t/hybrid-custody/4016) where core concepts were introduced and discussed.
+- [Forum Post](https://forum.flow.com/t/hybrid-custody/4016) where core concepts were introduced and discussed.
 - [GitHub repository](https://github.com/onflow/hybrid-custody) where `HybridCustody` core contracts and scripts are
   maintained. Check out the repository for more advanced script or transaction examples.
 - [Example](https://github.com/jribbink/magic-link-hc-sample/) Account Linking project with

--- a/docs/build/guides/account-linking/parent-accounts.md
+++ b/docs/build/guides/account-linking/parent-accounts.md
@@ -47,7 +47,7 @@ The basic idea in the Hybrid Custody model is relatively simple. A parent accoun
 (albeit restricted) access on another account. The account which has delegated authority over itself to the parent
 account is the child account.
 
-In the [Hybrid Custody Model](https://forum.onflow.org/t/hybrid-custody/4016), this child account would have shared
+In the [Hybrid Custody Model](https://forum.flow.com/t/hybrid-custody/4016), this child account would have shared
 access between the app - the entity which created and likely custodies the account - and the linked parent account.
 
 How does this delegation occur? Typically when we think of shared account access in crypto, we think keys. However,
@@ -127,7 +127,6 @@ they allow direct retrieval of encapsulated `&Account` Capabilities. These owned
 are simply `OwnedAccount` Capabilities instead of `ChildAccount` Capabilities.
 
 ![HybridCustody Total Overview](./resources/hybrid_custody_low_level.png)
-
 
 ### Considerations
 
@@ -215,7 +214,7 @@ import "HybridCustody"
 ///
 access(all)
 fun getViews(_ address: Address, _ resolverCollectionPath: PublicPath): {UInt64: MetadataViews.Display} {
-    
+
     let account: PublicAccount = getAccount(address)
     let views: {UInt64: MetadataViews.Display} = {}
 
@@ -243,14 +242,14 @@ fun main(address: Address, resolverCollectionPath: PublicPath): {Address: {UInt6
     let allViews: {Address: {UInt64: MetadataViews.Display}} = {
             address: getViews(address, resolverCollectionPath)
         }
-    
-    /* Iterate over any associated accounts */ 
+
+    /* Iterate over any associated accounts */
     //
     let seen: [Address] = [address]
     if let managerRef = getAuthAccount<auth(BorrowValue) &Account>(address)
         .storage
         .borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
-        
+
         for childAccount in managerRef.getChildAddresses() {
             allViews.insert(key: childAccount, getViews(address, resolverCollectionPath))
             seen.append(childAccount)
@@ -264,7 +263,7 @@ fun main(address: Address, resolverCollectionPath: PublicPath): {Address: {UInt6
         }
     }
 
-    return allViews 
+    return allViews
 }
 ```
 
@@ -332,7 +331,7 @@ fun main(address: Address): {Address: {Type: UFix64}} {
     if let managerRef = getAuthAccount<auth(BorrowValue) &Account>(address)
         .storage
         .borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
-        
+
         for childAccount in managerRef.getChildAddresses() {
             balances.insert(key: childAccount, getAllBalancesInStorage(address))
             seen.append(childAccount)
@@ -346,7 +345,7 @@ fun main(address: Address): {Address: {Type: UFix64}} {
         }
     }
 
-    return balances 
+    return balances
 }
 ```
 
@@ -418,8 +417,8 @@ transaction(
         // ...
     }
 }
-      
-          
+
+
 
 ```
 

--- a/docs/build/guides/mobile/react-native-quickstart.md
+++ b/docs/build/guides/mobile/react-native-quickstart.md
@@ -74,14 +74,16 @@ Now that your app is running, you can configure FCL. Within the main project dir
 > **Create file:** `./flow/config.js`
 
 ```javascript ./flow/config.js
-import { config } from "@onflow/fcl";
+import { config } from '@onflow/fcl';
 
 config({
-  "accessNode.api": "https://rest-testnet.onflow.org", // Mainnet: "https://rest-mainnet.onflow.org"
-  "discovery.wallet": "https://fcl-discovery.onflow.org/testnet/authn", // Mainnet: "https://fcl-discovery.onflow.org/authn"
-  "discovery.authn.endpoint": "https://fcl-discovery.onflow.org/api/testnet/authn", // Mainnet: "https://fcl-discovery.onflow.org/api/authn"
-})
+  'accessNode.api': 'https://rest-testnet.onflow.org', // Mainnet: "https://rest-mainnet.onflow.org"
+  'discovery.wallet': 'https://fcl-discovery.onflow.org/testnet/authn', // Mainnet: "https://fcl-discovery.onflow.org/authn"
+  'discovery.authn.endpoint':
+    'https://fcl-discovery.onflow.org/api/testnet/authn', // Mainnet: "https://fcl-discovery.onflow.org/api/authn"
+});
 ```
+
 📣 **Tip**: It's recommend to replace these values with environment variables for easy deployments across different environments like development/production or Testnet/Mainnet.
 
 - The `accessNode.api` key specifies the address of a Flow access node. Flow provides these, but in the future access to Flow may be provided by other 3rd parties, through their own access nodes.
@@ -111,7 +113,7 @@ The main screen for React Native apps is located in `./App.js` or in `./App.tsx`
 ```jsx ./App.js
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View } from 'react-native';
-import "./flow/config";
+import './flow/config';
 
 export default function App() {
   return (
@@ -130,8 +132,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-
-
 ```
 
 Now we're ready to start talking to Flow!
@@ -140,7 +140,7 @@ Now we're ready to start talking to Flow!
 
 To authenticate a user, you'll need to render a `ServiceDiscovery` component provided by `fcl-react-native`. Alternatively you can build your own component using `useServiceDiscovery`.
 
-Unauthenticate is as simple as calling `fcl.unauthenticate()`.  Once authenticated, FCL sets an object called `fcl.currentUser` which exposes methods for watching changes in user data, signing transactions, and more. For more information on the `currentUser`, read more [here](../../../tools/clients/fcl-js/api.md#current-user).
+Unauthenticate is as simple as calling `fcl.unauthenticate()`. Once authenticated, FCL sets an object called `fcl.currentUser` which exposes methods for watching changes in user data, signing transactions, and more. For more information on the `currentUser`, read more [here](../../../tools/clients/fcl-js/api.md#current-user).
 
 Let's add in a few components and buttons buttons for sign up/login and also subscribe to changes on the `currentUser`. When the user is updated (which it will be after authentication), we'll set the user state in our component to reflect this. To demonstrate user authenticated sessions, we'll conditionally render a component based on if the user is or is not logged in.
 
@@ -150,37 +150,36 @@ This is what your file should look like now:
 
 ```jsx ./App.js
 import { Text, View, Button } from 'react-native';
-import "./flow/config";
+import './flow/config';
 
-import { useState, useEffect } from "react";
-import * as fcl from "@onflow/fcl/dist/fcl-react-native";
+import { useState, useEffect } from 'react';
+import * as fcl from '@onflow/fcl/dist/fcl-react-native';
 
 export default function App() {
+  const [user, setUser] = useState({ loggedIn: null });
 
-  const [user, setUser] = useState({loggedIn: null})
-
-  useEffect(() => fcl.currentUser.subscribe(setUser), [])
+  useEffect(() => fcl.currentUser.subscribe(setUser), []);
 
   const AuthedState = () => {
     return (
       <View>
-        <Text>Address: {user?.addr ?? "No Address"}</Text>
-        <Button onPress={fcl.unauthenticate} title='Log Out'/>
+        <Text>Address: {user?.addr ?? 'No Address'}</Text>
+        <Button onPress={fcl.unauthenticate} title="Log Out" />
       </View>
-    )
-  }
+    );
+  };
 
   if (user.loggedIn) {
-    return <View style={styles.container}>
-       <Text>Flow App</Text>
+    return (
+      <View style={styles.container}>
+        <Text>Flow App</Text>
         <AuthedState />
         <StatusBar style="auto" />
-     </View>
+      </View>
+    );
   }
 
-  return (
-    <fcl.ServiceDiscovery fcl={fcl}/>
-  )
+  return <fcl.ServiceDiscovery fcl={fcl} />;
 }
 
 const styles = StyleSheet.create({
@@ -191,7 +190,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-
 ```
 
 You should now be able to log in or sign up a user and unauthenticate them. Upon logging in or signing up your users will see a popup where they can choose between wallet providers. Let's select the [Blocto wallet](https://blocto.portto.io/) for this example to create an account. Upon completing authentication, you'll see the component change and the user's wallet address appear on the screen if you've completed this properly.
@@ -203,21 +201,23 @@ One of the main things you'll often need to do when building a dapp is query the
 > **Replace file:** `./flow/config.js`
 
 ```javascript ./flow/config.js
-import { config } from "@onflow/fcl";
+import { config } from '@onflow/fcl';
 
 config({
- "accessNode.api": "https://rest-testnet.onflow.org", // Mainnet: "https://rest-mainnet.onflow.org"
-  "discovery.wallet": "https://fcl-discovery.onflow.org/testnet/authn", // Mainnet: "https://fcl-discovery.onflow.org/authn"
-  "discovery.authn.endpoint": "https://fcl-discovery.onflow.org/api/testnet/authn",
-  "0xProfile": "0xba1132bc08f82fe2" // The account address where the Profile smart contract lives on Testnet
-})
+  'accessNode.api': 'https://rest-testnet.onflow.org', // Mainnet: "https://rest-mainnet.onflow.org"
+  'discovery.wallet': 'https://fcl-discovery.onflow.org/testnet/authn', // Mainnet: "https://fcl-discovery.onflow.org/authn"
+  'discovery.authn.endpoint':
+    'https://fcl-discovery.onflow.org/api/testnet/authn',
+  '0xProfile': '0xba1132bc08f82fe2', // The account address where the Profile smart contract lives on Testnet
+});
 ```
 
 If you want to see the on chain smart contract we'll be speaking with next, you can view the [Profile Contract](https://testnet.flowdiver.io/contract/A.ba1132bc08f82fe2.Profile) source code but again for this tutorial it's not necessary you understand it.
 
-**First, lets query the contract to see what the user's profile name is.** 
+**First, lets query the contract to see what the user's profile name is.**
 
-A few things need to happen in order to do that: 
+A few things need to happen in order to do that:
+
 1. We need to import the contract and pass it the user's account address as an argument.
 2. Execute the script using `fcl.query`.
 3. Set the result of the script to the app state in React so we can display the profile name in our browser.
@@ -231,16 +231,15 @@ Take a look at the new code. We'll explain each new piece as we go. Remember, th
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View, Button } from 'react-native';
 import { useEffect, useState } from 'react';
-import './flow/config'
+import './flow/config';
 
-import * as fcl from "@onflow/fcl/dist/fcl-react-native";
+import * as fcl from '@onflow/fcl/dist/fcl-react-native';
 
 export default function App() {
+  const [user, setUser] = useState({ loggedIn: null });
+  const [name, setName] = useState(''); // NEW
 
-  const [user, setUser] = useState({loggedIn: null})
-  const [name, setName] = useState('') // NEW
-
-  useEffect(() => fcl.currentUser.subscribe(setUser), [])
+  useEffect(() => fcl.currentUser.subscribe(setUser), []);
 
   // NEW
   const sendQuery = async () => {
@@ -252,34 +251,37 @@ export default function App() {
           return Profile.read(address)
         }
       `,
-      args: (arg, t) => [arg(user.addr, t.Address)]
-    })
+      args: (arg, t) => [arg(user.addr, t.Address)],
+    });
 
-    setName(profile?.name ?? 'No Profile')
-  }
+    setName(profile?.name ?? 'No Profile');
+  };
 
   const AuthedState = () => {
     return (
-      <View >
-        <Text>Address: {user?.addr ?? "No Address"}</Text>{/* NEW */}
-        <Text>Profile Name: {name ?? "--"}</Text>{/* NEW */}
-        <Button onPress={sendQuery} title='Send Query'/>{/* NEW */}
-        <Button onPress={fcl.unauthenticate} title='Log Out'/>
+      <View>
+        <Text>Address: {user?.addr ?? 'No Address'}</Text>
+        {/* NEW */}
+        <Text>Profile Name: {name ?? '--'}</Text>
+        {/* NEW */}
+        <Button onPress={sendQuery} title="Send Query" />
+        {/* NEW */}
+        <Button onPress={fcl.unauthenticate} title="Log Out" />
       </View>
-    )
-  }
+    );
+  };
 
   if (user.loggedIn) {
-    return <View style={styles.container}>
+    return (
+      <View style={styles.container}>
         <Text>Flow App</Text>
         <AuthedState />
         <StatusBar style="auto" />
-     </View>
+      </View>
+    );
   }
 
-  return (
-    <fcl.ServiceDiscovery fcl={fcl}/>
-  )
+  return <fcl.ServiceDiscovery fcl={fcl} />;
 }
 
 const styles = StyleSheet.create({
@@ -290,7 +292,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-
 ```
 
 A few things happened. In our `AuthedState` component, we added a button to send a query for the user's profile name and a `Text` to display the result above it. The corresponding `useState` initialization can be seen at the top of the component.
@@ -306,13 +307,13 @@ await fcl.query({
       return Profile.read(address)
     }
   `,
-  args: (arg, t) => [arg(user.addr, t.Address)]
+  args: (arg, t) => [arg(user.addr, t.Address)],
 });
 ```
 
 Inside the query you'll see we set two things: `cadence` and `args`. Cadence is Flow's smart contract language we mentioned. For this tutorial, when you look at it you just need to notice that it's importing the `Profile` contract from the account we named `0xProfile` earlier in our config file, then also taking an account address, and reading it. That's it until you're ready to [learn more Cadence](https://cadence-lang.org/docs).
 
-In the `args` section, we are simply passing it our user's account address from the user we set in state after authentication and giving it a type of `Address`.  For more possible types, [see this reference](../../../tools/clients/fcl-js/api.md#ftype).
+In the `args` section, we are simply passing it our user's account address from the user we set in state after authentication and giving it a type of `Address`. For more possible types, [see this reference](../../../tools/clients/fcl-js/api.md#ftype).
 
 Go ahead and click the "Send Query" button. You should see "No Profile." That's because we haven't initialized the account yet.
 
@@ -322,7 +323,7 @@ For the Profile contract to store a Profile in a user's account, it does so by i
 
 > There's a lot more to resources in Cadence than we'll cover in this guide, so if you'd like to know more, check out [this Cadence intro](https://cadence-lang.org/docs).
 
-To do this resource initialization on an account, we're going to add another function called `initAccount`. Inside of that function, we're going to add some Cadence code which says, *"Hey, does this account have a profile? If it doesn't, let's add one."* We do that using something called a "transaction." Transactions occur when you want to change the state of the blockchain, in this case, some data in a resource, in a specific account. And there is a cost (transaction fee) in order to do that; unlike a query.
+To do this resource initialization on an account, we're going to add another function called `initAccount`. Inside of that function, we're going to add some Cadence code which says, _"Hey, does this account have a profile? If it doesn't, let's add one."_ We do that using something called a "transaction." Transactions occur when you want to change the state of the blockchain, in this case, some data in a resource, in a specific account. And there is a cost (transaction fee) in order to do that; unlike a query.
 
 That's where we jump back into FCL code. Instead of `query`, we use `mutate` for transactions. And because there is a cost, we need to add a few fields that tell Flow who is proposing the transaction, who is authorizing it, who is paying for it, and how much they're willing to pay for it. Those fields — not surprisingly — are called: `proposer`, `authorizer`, `payer`, and `limit`. For more information on these signatory roles, check out [this doc](../../basics/transactions.md#signer-roles).
 
@@ -352,12 +353,12 @@ const initAccount = async () => {
     payer: fcl.authz,
     proposer: fcl.authz,
     authorizations: [fcl.authz],
-    limit: 50
-  })
+    limit: 50,
+  });
 
-  const transaction = await fcl.tx(transactionId).onceExecuted()
-  console.log(transaction)
-}
+  const transaction = await fcl.tx(transactionId).onceExecuted();
+  console.log(transaction);
+};
 ```
 
 You can see the new fields we talked about. You'll also notice `fcl.authz`. That's shorthand for "use the current user to authorize this transaction", (you could also write it as `fcl.currentUser.authorization`). If you want to learn more about transactions and signing transactions, you can [view the docs here](../../basics/transactions.md). For this example, we'll keep it simple with the user being each of these roles.
@@ -374,16 +375,15 @@ Now your `index.js` file should look like this (we also added a button for calli
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View, Button } from 'react-native';
 import { useEffect, useState } from 'react';
-import './flow/config'
+import './flow/config';
 
-import * as fcl from "@onflow/fcl/dist/fcl-react-native";
+import * as fcl from '@onflow/fcl/dist/fcl-react-native';
 
 export default function App() {
+  const [user, setUser] = useState({ loggedIn: null });
+  const [name, setName] = useState('');
 
-  const [user, setUser] = useState({loggedIn: null})
-  const [name, setName] = useState('')
-
-  useEffect(() => fcl.currentUser.subscribe(setUser), [])
+  useEffect(() => fcl.currentUser.subscribe(setUser), []);
 
   const sendQuery = async () => {
     const profile = await fcl.query({
@@ -394,11 +394,11 @@ export default function App() {
           return Profile.read(address)
         }
       `,
-      args: (arg, t) => [arg(user.addr, t.Address)]
-    })
+      args: (arg, t) => [arg(user.addr, t.Address)],
+    });
 
-    setName(profile?.name ?? 'No Profile')
-  }
+    setName(profile?.name ?? 'No Profile');
+  };
 
   // NEW
   const initAccount = async () => {
@@ -424,36 +424,37 @@ export default function App() {
       payer: fcl.authz,
       proposer: fcl.authz,
       authorizations: [fcl.authz],
-      limit: 50
-    })
-  
-    const transaction = await fcl.tx(transactionId).onceExecuted()
-    console.log(transaction)
-  }
+      limit: 50,
+    });
+
+    const transaction = await fcl.tx(transactionId).onceExecuted();
+    console.log(transaction);
+  };
 
   const AuthedState = () => {
     return (
-      <View >
-        <Text>Address: {user?.addr ?? "No Address"}</Text>
-        <Text>Profile Name: {name ?? "--"}</Text>
-        <Button onPress={sendQuery} title='Send Query'/>
-        <Button onPress={initAccount} title='Init Account'/>{/* NEW */}
-        <Button onPress={fcl.unauthenticate} title='Log Out'/>
+      <View>
+        <Text>Address: {user?.addr ?? 'No Address'}</Text>
+        <Text>Profile Name: {name ?? '--'}</Text>
+        <Button onPress={sendQuery} title="Send Query" />
+        <Button onPress={initAccount} title="Init Account" />
+        {/* NEW */}
+        <Button onPress={fcl.unauthenticate} title="Log Out" />
       </View>
-    )
-  }
+    );
+  };
 
   if (user.loggedIn) {
-    return <View style={styles.container}>
+    return (
+      <View style={styles.container}>
         <Text>Flow App</Text>
         <AuthedState />
         <StatusBar style="auto" />
-     </View>
+      </View>
+    );
   }
 
-  return (
-    <fcl.ServiceDiscovery fcl={fcl}/>
-  )
+  return <fcl.ServiceDiscovery fcl={fcl} />;
 }
 
 const styles = StyleSheet.create({
@@ -464,7 +465,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-
 ```
 
 Press the "Init Account" button you should see the wallet ask you to approve a transaction. After approving, you will see a transaction response appear in your console (make sure to have that open). It may take a few moments. With the transaction result printed, you can use the `transactionId` to look up the details of the transaction using a [block explorer](https://testnet.flowscan.io/).
@@ -494,15 +494,15 @@ const executeTransaction = async () => {
         }
       }
     `,
-    args: (arg, t) => [arg("Flow Developer", t.String)],
+    args: (arg, t) => [arg('Flow Developer', t.String)],
     payer: fcl.authz,
     proposer: fcl.authz,
     authorizations: [fcl.authz],
-    limit: 50
-  })
+    limit: 50,
+  });
 
-  fcl.tx(transactionId).subscribe(res => setTransactionStatus(res.status))
-}
+  fcl.tx(transactionId).subscribe((res) => setTransactionStatus(res.status));
+};
 ```
 
 Here you can see our argument is "Flow Developer" and at the bottom we've called the `subscribe` method instead of `onceExecuted`.
@@ -515,17 +515,16 @@ Let's see how that works inside our whole `index.js` file. But, let's also set t
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View, Button } from 'react-native';
 import { useEffect, useState } from 'react';
-import './flow/config'
+import './flow/config';
 
-import * as fcl from "@onflow/fcl/dist/fcl-react-native";
+import * as fcl from '@onflow/fcl/dist/fcl-react-native';
 
 export default function App() {
+  const [user, setUser] = useState({ loggedIn: null });
+  const [name, setName] = useState('');
+  const [transactionStatus, setTransactionStatus] = useState(null); // NEW
 
-  const [user, setUser] = useState({loggedIn: null})
-  const [name, setName] = useState('')
-  const [transactionStatus, setTransactionStatus] = useState(null) // NEW
-
-  useEffect(() => fcl.currentUser.subscribe(setUser), [])
+  useEffect(() => fcl.currentUser.subscribe(setUser), []);
 
   const sendQuery = async () => {
     const profile = await fcl.query({
@@ -536,11 +535,11 @@ export default function App() {
           return Profile.read(address)
         }
       `,
-      args: (arg, t) => [arg(user.addr, t.Address)]
-    })
+      args: (arg, t) => [arg(user.addr, t.Address)],
+    });
 
-    setName(profile?.name ?? 'No Profile')
-  }
+    setName(profile?.name ?? 'No Profile');
+  };
 
   const initAccount = async () => {
     const transactionId = await fcl.mutate({
@@ -565,12 +564,12 @@ export default function App() {
       payer: fcl.authz,
       proposer: fcl.authz,
       authorizations: [fcl.authz],
-      limit: 50
-    })
-  
-    const transaction = await fcl.tx(transactionId).onceExecuted()
-    console.log(transaction)
-  }
+      limit: 50,
+    });
+
+    const transaction = await fcl.tx(transactionId).onceExecuted();
+    console.log(transaction);
+  };
 
   // NEW
   const executeTransaction = async () => {
@@ -589,41 +588,44 @@ export default function App() {
           }
         }
       `,
-      args: (arg, t) => [arg("Flow Developer", t.String)],
+      args: (arg, t) => [arg('Flow Developer', t.String)],
       payer: fcl.authz,
       proposer: fcl.authz,
       authorizations: [fcl.authz],
-      limit: 50
-    })
-  
-    fcl.tx(transactionId).subscribe(res => setTransactionStatus(res.status))
-  }
+      limit: 50,
+    });
+
+    fcl.tx(transactionId).subscribe((res) => setTransactionStatus(res.status));
+  };
 
   const AuthedState = () => {
     return (
-      <View >
-        <Text>Address: {user?.addr ?? "No Address"}</Text>
-        <Text>Profile Name: {name ?? "--"}</Text>
-        <Text>Transaction Status: {transactionStatus ?? "--"}</Text>{/* NEW */}
-        <Button onPress={sendQuery} title='Send Query'/>
-        <Button onPress={initAccount} title='Init Account'/>{/* NEW */}
-        <Button onPress={executeTransaction} title='Execute Transaction'/>{/* NEW */}
-        <Button onPress={fcl.unauthenticate} title='Log Out'/>
+      <View>
+        <Text>Address: {user?.addr ?? 'No Address'}</Text>
+        <Text>Profile Name: {name ?? '--'}</Text>
+        <Text>Transaction Status: {transactionStatus ?? '--'}</Text>
+        {/* NEW */}
+        <Button onPress={sendQuery} title="Send Query" />
+        <Button onPress={initAccount} title="Init Account" />
+        {/* NEW */}
+        <Button onPress={executeTransaction} title="Execute Transaction" />
+        {/* NEW */}
+        <Button onPress={fcl.unauthenticate} title="Log Out" />
       </View>
-    )
-  }
+    );
+  };
 
   if (user.loggedIn) {
-    return <View style={styles.container}>
+    return (
+      <View style={styles.container}>
         <Text>Flow App</Text>
         <AuthedState />
         <StatusBar style="auto" />
-     </View>
+      </View>
+    );
   }
 
-  return (
-    <fcl.ServiceDiscovery fcl={fcl}/>
-  )
+  return <fcl.ServiceDiscovery fcl={fcl} />;
 }
 
 const styles = StyleSheet.create({
@@ -634,7 +636,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-
 ```
 
 Now if you click the "Execute Transaction" button you'll see the statuses update next to "Transaction Status." When you see "4" that means it's sealed! Status code meanings [can be found here](../../../tools/clients/fcl-js/api.md#transaction-statuses).
@@ -643,14 +644,17 @@ If you query the account profile again, "Profile Name:" should now display "Flow
 That's it! You now have a shippable Flow dapp that can auth, query, init accounts, and mutate the chain. This is just the beginning. There is so much more to know. We have a lot more resources to help you build. To dive deeper, here are a few good places for taking the next steps:
 
 **Cadence**
+
 - [Cadence Playground Tutorials](https://cadence-lang.org/docs/tutorial/first-steps)
 - [Cadence Hello World Video](https://www.youtube.com/watch?v=pRz7EzrWchs)
-- [Why Cadence?](https://www.onflow.org/post/flow-blockchain-cadence-programming-language-resources-assets)
+- [Why Cadence?](https://www.flow.com/post/flow-blockchain-cadence-programming-language-resources-assets)
 
 **Full Stack NFT Marketplace Example**
+
 - [Beginner Example: CryptoDappy](https://github.com/bebner/crypto-dappy)
 
 **More FCL**
+
 - [FCL API Quick Reference](../../../tools/clients/fcl-js/api)
 - [More on Scripts](../../../tools/clients/fcl-js/scripts.md)
 - [More on Transactions](../../../tools/clients/fcl-js/transactions.md)

--- a/docs/build/smart-contracts/deploying.md
+++ b/docs/build/smart-contracts/deploying.md
@@ -39,8 +39,10 @@ Anyone can deploy and update contracts on mainnet. Audits are encouraged but not
 </Callout>
 
 ### Create and deploy a mainnet project
+
 The tool of choice is Flow CLI, there are quickstarts and guides that use Flow CLI, [Getting Started](../getting-started/flow-cli)
-- It is highly encouraged to test your contracts, transactions and scripts on Testnet, have strong smart contract test coverage and follow any additional guidelines set out here: [Smart Contract Testing Guidelines](./testing.md). 
+
+- It is highly encouraged to test your contracts, transactions and scripts on Testnet, have strong smart contract test coverage and follow any additional guidelines set out here: [Smart Contract Testing Guidelines](./testing.md).
 - Follow the Flow CLI instructions to [Create a Project](../../tools/flow-cli/index.md). You have the Flow CLI installed and ran `flow init` in your project folder and generating a `flow.json` file
 - Mainnet account: You completed the mainnet account setup, (see above) and have your key pair and mainnet address ready.
 - [Deploy your project](../../tools/flow-cli/deployment/deploy-project-contracts.md), notice that your account now has contracts deployed on mainnet.
@@ -66,13 +68,11 @@ Currently, **historical event data is not migrated between sporks,** so you'll n
 
 More Information on [Sporks](../../networks/node-ops/node-operation/spork)
 
-
 ### Testnet
-
 
 The Flow test network, known as Flow Testnet, exists to help developers test their software and smart contracts against a live network. It's also used as a means of releasing and testing new protocol and smart contract features before they are integrated into Flow's main network (Mainnet).
 
-When the Flow protocol is updated or a new version of Cadence is released, those updates will always be made available on the [Flow Emulator](../../tools/emulator) _before_ they're integrated into Flow Testnet or Flow Mainnet. 
+When the Flow protocol is updated or a new version of Cadence is released, those updates will always be made available on the [Flow Emulator](../../tools/emulator) _before_ they're integrated into Flow Testnet or Flow Mainnet.
 
 ## Getting Started on Testnet
 
@@ -81,23 +81,21 @@ If you need to create a flow.json file to store information about accounts and c
 To create accounts and generate keys, make sure to install [Flow CLI](../../tools/flow-cli/install). Flow CLI provides convenient functions to simplifies interacting with the blockchain.
 </Callout>
 
-
 ### Creating an Account
 
-There is a simple Flow CLI command to run to create an account. `flow accounts create` command will create a new account and generate a key pair then add the account to your flow.json. The command will try and You can also use the [Testnet Faucet](https://testnet-faucet-v2.onflow.org/) to create and fund an account.
+There is a simple Flow CLI command to run to create an account. `flow accounts create` command will create a new account and generate a key pair then add the account to your flow.json. The command will try and You can also use the [Testnet Faucet](https://faucet.flow.com/fund-account) to create and fund an account.
 
-More information about [Flow CLI](../../tools/flow-cli/accounts/create-accounts) and creating accounts. 
+More information about [Flow CLI](../../tools/flow-cli/accounts/create-accounts) and creating accounts.
 
 ### Creating and deploying a Project
 
 Flow CLI can be used to create a Cadence project and stay organized, [Flow CLI: Create a project](../../tools/flow-cli). This will make deployment much easiler and help with the iterative development process.
 
-After you have a project created and want to deploy your Cadence; contracts, transactions and scripts. 
+After you have a project created and want to deploy your Cadence; contracts, transactions and scripts.
 `flow accounts add-contract <CONTRACT_PATH> --signer <ACCOUNT_NAME> --network testnet` will deploy your contract to testnet.
 More information on how to use Flow CLI to [deploy](../../tools/flow-cli/deployment/deploy-project-contracts.md).
 
 Make sure Flow project was initialized in the previous step and the `flow.json` is present.
-
 
 ### Making Use of Core Contracts
 
@@ -105,13 +103,11 @@ Flow Testnet comes with some useful contracts already deployed, called **core co
 
 Once your accounts are set up and you're ready to develop, you can look over [some code examples from the Flow Go SDK](https://github.com/onflow/flow-go-sdk/tree/master/examples).
 
-
 ### Breaking Changes
 
 The Flow blockchain is improved continuously and thus version updates to Cadence, Flow node software, and the Flow SDKs will contain important updates as well as breaking changes.
 
-You should anticipate future updates and join the community ([Forum](https://forum.onflow.org/) or [Discord](https://discord.com/invite/J6fFnh2xx6)) to stay tuned on important announcements. Notices and guidelines for changes will be provided as early as possible.
-
+You should anticipate future updates and join the community ([Forum](https://forum.flow.com/) or [Discord](https://discord.com/invite/J6fFnh2xx6)) to stay tuned on important announcements. Notices and guidelines for changes will be provided as early as possible.
 
 ### Testnet Sporking
 
@@ -119,10 +115,6 @@ You should anticipate future updates and join the community ([Forum](https://for
 
 Currently, **historical event data is not migrated between sporks.** You'll need to design your application with this in mind. We recognize the usefulness of historical event data and plan on adding a means of accessing it in the near future. Only one previous spork data is available through old Access Node.
 
-
 <Callout type="warning">
 Flow Testnet is explicitly for experimentation and testing and should not be used to exchange "real value" (e.g. developing a fiat money on/off-ramp for your testnet application).
 </Callout>
-
-
-

--- a/docs/ecosystem/faucets.md
+++ b/docs/ecosystem/faucets.md
@@ -13,11 +13,11 @@ Network Faucets provide free Flow tokens for testing purposes, functioning like 
 
 ## Flow Faucet
 
-[Flow Faucet](https://testnet-faucet.onflow.org/) is a dedicated tool that provides a seamless way to acquire small amounts of Flow tokens for testing and development purposes on the Flow blockchain's testnet environment.
+[Flow Faucet](https://faucet.flow.com/fund-account) is a dedicated tool that provides a seamless way to acquire small amounts of Flow tokens for testing and development purposes on the Flow blockchain's testnet environment.
 
 ### Supported Networks
 
-- [Testnet](https://testnet-faucet.onflow.org/)
+- [Testnet](https://faucet.flow.com/fund-account)
 
 ## LearnWeb3 Flow Faucet
 

--- a/docs/ecosystem/index.mdx
+++ b/docs/ecosystem/index.mdx
@@ -14,7 +14,7 @@ import { useLocation } from '@docusaurus/router';
     {
       type: 'link',
       label: 'Flow Forum',
-      href: 'https://forum.onflow.org/',
+      href: 'https://forum.flow.com/',
       description: 'Engage with the Flow community, discuss ideas, and seek support on the Flow Blockchain Forum.',
       customProps: {
         icon: "🏛️"

--- a/docs/networks/flow-networks/accessing-mainnet.md
+++ b/docs/networks/flow-networks/accessing-mainnet.md
@@ -10,7 +10,7 @@ description: Guide to mainnet access
 The Flow Mainnet is available for access at this URL:
 
 ```
-access.mainnet.nodes.onflow.org:9000
+access.mainnet.nodes.flow.com:9000
 ```
 
 For example, to access the network using the [Flow Go SDK](https://github.com/onflow/flow-go-sdk):
@@ -19,7 +19,7 @@ For example, to access the network using the [Flow Go SDK](https://github.com/on
 import "github.com/onflow/flow-go-sdk/client"
 
 func main() {
-  flowAccessAddress := "access.mainnet.nodes.onflow.org:9000"
+  flowAccessAddress := "access.mainnet.nodes.flow.com:9000"
   flowClient, _ := client.New(flowAccessAddress, grpc.WithInsecure())
   // ...
 }
@@ -59,7 +59,7 @@ Public Key       1bdc5...
 
 > **Note**: By default, this command generates an ECDSA key pair on the P-256 curve. Keep in mind the CLI is intended for development purposes only and is not recommended for production use. Handling keys using a Key Management Service is the best practice.
 
-Take a note of the public key and go back to Flow Port. Open the ["Create a new account" page](https://port.onflow.org/transaction?hash=a0a78aa7821144efd5ebb974bb52ba04609ce76c3863af9d45348db93937cf98&showcode=false&weight=1000&halg=3).
+Take a note of the public key and go back to Flow Port. Open the ["Create a new account" page](https://port.flow.com/transaction?hash=a0a78aa7821144efd5ebb974bb52ba04609ce76c3863af9d45348db93937cf98&showcode=false&weight=1000&halg=3).
 
 On the page, enter your public key from the CLI, ensure the hash algorithm is set to `SHA3_256` and the weight is set to `1000`. Finally, check the box confirming correctness and hit 'Submit'.
 

--- a/docs/networks/flow-port/index.md
+++ b/docs/networks/flow-port/index.md
@@ -8,60 +8,63 @@ Flow Port is an account management tool for Flow. Flow Port allows you to create
 Typically, your wallet provider will support most of these features. However, should your wallet provider not do so, or should you wish to use this tool for any other reason, Flow Foundation makes it available for you.
 
 ## Creating an Account
+
 In order to access Flow Port, you must have a valid Flow address. If you do not have a Flow address you can create one by installing a [Flow compatible wallet](../../ecosystem/wallets).
 
 ### Flow Wallet
 
 #### Creating Account Through Flow Port: Navigate To Flow Port
 
- 1. Using Google Chrome, Navigate to [Flow Port](https://port.onflow.org/).
+1.  Using Google Chrome, Navigate to [Flow Port](https://port.flow.com/).
 
- 2. Click on 'Sign Up'
+2.  Click on 'Sign Up'
 
- 3. Click on Flow Wallet and choose Chrome extension or Mobile
+3.  Click on Flow Wallet and choose Chrome extension or Mobile
 
- 4. You should be logged into Flow Port! You can now see your account address in Flow Port and access Flow features for your account 
+4.  You should be logged into Flow Port! You can now see your account address in Flow Port and access Flow features for your account
 
 ### Ledger
+
 #### Before You Start
 
- 1. Ensure you have:
+1.  Ensure you have:
 
-     - a.) [Ledger Live](https://www.ledger.com/ledger-live) installed on your computer
+    - a.) [Ledger Live](https://www.ledger.com/ledger-live) installed on your computer
 
-     - b.) [Initialized](https://support.ledger.com/hc/en-us/articles/360017362160-Flow-FLOW-?support=true) your Ledger Device.
+    - b.) [Initialized](https://support.ledger.com/hc/en-us/articles/360017362160-Flow-FLOW-?support=true) your Ledger Device.
 
 #### Install the Flow App
 
- 1. Connect your Ledger Device to your computer and open Ledger Live.
+1.  Connect your Ledger Device to your computer and open Ledger Live.
 
- 2. Make sure your Ledger device firmware is up to date. You can check this by clicking on **‘Manager’** from the side navigation bar. Choose to install the update if one is available
+2.  Make sure your Ledger device firmware is up to date. You can check this by clicking on **‘Manager’** from the side navigation bar. Choose to install the update if one is available
 
-     - a.) NOTE: Sometimes the install option doesn't show up, or it is not clickable. If this is the case, wait for a little bit of time to see if it appears, or restart the ledger live app if necessary.
+    - a.) NOTE: Sometimes the install option doesn't show up, or it is not clickable. If this is the case, wait for a little bit of time to see if it appears, or restart the ledger live app if necessary.
 
- 3. On the Manager screen in Ledger Live and search for ‘Flow’.
+3.  On the Manager screen in Ledger Live and search for ‘Flow’.
 
- 4. You should see the Flow App. Install it and follow the instructions on the device.
+4.  You should see the Flow App. Install it and follow the instructions on the device.
 
-     - a.) NOTE: If the Flow App does not appear, it may be because you are on an outdated version. Please ensure you are on the most updated version.
+    - a.) NOTE: If the Flow App does not appear, it may be because you are on an outdated version. Please ensure you are on the most updated version.
 
 #### Navigate to Flow Port to Create an Address
 
- 1. Navigate to [Flow Port](https://port.onflow.org/).
+1.  Navigate to [Flow Port](https://port.flow.com/).
 
- 2. Click on 'Sign Up' if you need to create a new Flow Account.
+2.  Click on 'Sign Up' if you need to create a new Flow Account.
 
- 3. Click on Ledger.
+3.  Click on Ledger.
 
- 4. Follow the prompts on the screen. Plug in your Ledger device and open the Flow App.
+4.  Follow the prompts on the screen. Plug in your Ledger device and open the Flow App.
 
- 5. Click on Create an account. Follow the prompts on your Ledger device.
+5.  Click on Create an account. Follow the prompts on your Ledger device.
 
- 6. Once your account address is created, you will be automatically logged into Flow Port.
+6.  Once your account address is created, you will be automatically logged into Flow Port.
 
 ## Staking & Delegating
 
 For a detailed walkthrough on how to use Flow Port for staking and delegating, please read the [Flow Port staking walkthrough](./staking-guide.md)
+
 ### How Do I Stake or Delegate?
 
 So you have decided you want to be a part of the Flow Network. Welcome! You are joining a group of people from all around the world that are a part of a movement centered around bringing decentralization, user empowerment, and transparency into the world. Below is a step-by-step guide that will assist you in the staking & delegation process.
@@ -71,80 +74,88 @@ So you have decided you want to be a part of the Flow Network. Welcome! You are 
 If you are using a custody provider who controls your account and private keys for you, such as Kraken, Finoa, or Coinlist, they all have different policies and processes for what you need to do to stake your tokens, the rewards you receive, and the fees that they take from your staking rewards.
 
 ### Starting a Manual Staking Transaction
- 1. You need to have FLOW in order to stake. Please see the [FLOW Token](../../build//core-contracts//03-flow-token.md) reference for information on how to become a FLOW holder.
 
- 2. Once you have FLOW tokens in your account, you can start staking through [Flow Port](https://port.onflow.org/) or, if applicable, with your [custody provider](#staking-via-a-custody-provider).
+1.  You need to have FLOW in order to stake. Please see the [FLOW Token](../../build//core-contracts//03-flow-token.md) reference for information on how to become a FLOW holder.
 
- 3. If you are using Flow Port, log-in with your Flow account address and navigate to the Stake/Delegate page. See the Manual Staking/Delegating section below for more information about what to do next.
+2.  Once you have FLOW tokens in your account, you can start staking through [Flow Port](https://port.flow.com/) or, if applicable, with your [custody provider](#staking-via-a-custody-provider).
+
+3.  If you are using Flow Port, log-in with your Flow account address and navigate to the Stake/Delegate page. See the Manual Staking/Delegating section below for more information about what to do next.
 
 ### Manual Staking/Delegating
+
 If you are not using a custody provider, there is more responsibility that you have to accept, because you have complete control of your tokens. You need to ensure that you are well informed about the staking process and potentially node operation process because you will have to manage those on your own. Please read the [staking documentation](../../networks/staking/index.md) before continuing with this guide.
 
 Below are the various options you can choose. Please be aware, that at this time you can only have 1 stake or 1 delegate per account. This means that if you want to do multiple stakes, multiple delegates, or a mixture of stakes and delegates, you will need to create multiple accounts to do so. Please read them carefully as it will help you understand which route is best for your situation:
-- Staking your own Node: You are responsible for running and maintaining a Flow Node. You are also solely responsible for providing the minimum stake for your   selected node (minimum 135,000 FLOW) and you have the technical know-how and bandwidth to run and operate a node in the Flow protocol.
+
+- Staking your own Node: You are responsible for running and maintaining a Flow Node. You are also solely responsible for providing the minimum stake for your selected node (minimum 135,000 FLOW) and you have the technical know-how and bandwidth to run and operate a node in the Flow protocol.
 - Delegating: You have FLOW tokens and you want to stake, without having to run your own node and/or have the full minimum stake required to run your own node. You can ‘delegate’ any amount of your FLOW tokens to an existing node operator and you will earn rewards.
 
 Please see a list [here](https://github.com/onflow/flow/blob/master/nodeoperators/NodeOperatorList.md) for all node operators that you can delegate to. This list will be updated as new node operators are onboarded onto the network.'
 
 ### Staking Your Own Node
-  1. Once you have navigated to the staking/delegating page in Flow Port, click on the 'Stake a Node' option.
 
-  2. Next, select the type of node you will be running.
+1. Once you have navigated to the staking/delegating page in Flow Port, click on the 'Stake a Node' option.
 
-  3. Input the amount of Flow you wish to stake with that node. You must stake at least the minimum in order for your stake request to be successfully processed. You are able to provide the minimum stake across multiple transactions. Meaning, you could execute your stake transaction with half of the minumum required. Then, before the next epoch, you can choose to 'Add Flow' to that pending stake to get it to the minimum stake required.
+2. Next, select the type of node you will be running.
 
-  4. Run the [bootstrapping instructions](../../networks/node-ops/node-operation/node-bootstrap.md) and provide the remaining technical details needed to stake a node.
+3. Input the amount of Flow you wish to stake with that node. You must stake at least the minimum in order for your stake request to be successfully processed. You are able to provide the minimum stake across multiple transactions. Meaning, you could execute your stake transaction with half of the minumum required. Then, before the next epoch, you can choose to 'Add Flow' to that pending stake to get it to the minimum stake required.
+
+4. Run the [bootstrapping instructions](../../networks/node-ops/node-operation/node-bootstrap.md) and provide the remaining technical details needed to stake a node.
 
 ### Delegating
-  1. Once you have navigated to the staking/delegating page in Flow Port, click on the Delegate option.
 
-  2. Next, you will specify which node operator you would like to delegate to and how many tokens you want to delegate to them.
+1. Once you have navigated to the staking/delegating page in Flow Port, click on the Delegate option.
 
-  3. Execute the transaction. You will now see your pending delegation that will be processed during the next epoch.
+2. Next, you will specify which node operator you would like to delegate to and how many tokens you want to delegate to them.
 
-  4. At this point, you can also cancel the pending delegation. On the pending delegation, you will see an `X` that you can click to initiate the cancelation transaction.
+3. Execute the transaction. You will now see your pending delegation that will be processed during the next epoch.
+
+4. At this point, you can also cancel the pending delegation. On the pending delegation, you will see an `X` that you can click to initiate the cancelation transaction.
 
 ## I Have Successfully Executed a Stake Transaction, Now What?
-  - Now that you have executed a stake transaction in either Flow Port or your custody provider’s portal, that transaction will sit in a pending status until it is processed, which will be at the next [Epoch](../../networks/staking/index.md#epochs) Date (which is currently weekly).
-  - During the next [Epoch](../../networks/staking/index.md#epochs), the transaction will be processed. If successful, the provided FLOW will be staked and the associated Node would be either **a)** included in the network protocol if it is a new node or **b)** continue to operate as is in the network protocol.
-  - You are now a part of Flow, and will begin to earn rewards for being a valued member of the network!
+
+- Now that you have executed a stake transaction in either Flow Port or your custody provider’s portal, that transaction will sit in a pending status until it is processed, which will be at the next [Epoch](../../networks/staking/index.md#epochs) Date (which is currently weekly).
+- During the next [Epoch](../../networks/staking/index.md#epochs), the transaction will be processed. If successful, the provided FLOW will be staked and the associated Node would be either **a)** included in the network protocol if it is a new node or **b)** continue to operate as is in the network protocol.
+- You are now a part of Flow, and will begin to earn rewards for being a valued member of the network!
 
 ## What Else Can I Do?
-  - Add additional stake to your existing stake. Any added FLOW will again sit in a pending status and be processed at the next epoch.
-  - Withdraw/re-stake your earned rewards. If you decide to withdraw your rewards, this action will happen instantly. If you decide to re-stake your rewards, the request will again sit in a pending status and will be processed at the next [Epoch](../../networks/staking/index.md#epochs).
-  - Withdraw Rewards and send your earnings to other accounts. If you decide that you want to withdraw your rewards and send those earnings to other accounts via the 'Send FLOW' function, you should first withdraw your rewards. Once in your account, you can send these funds to any other account via the 'Send FLOW' option.
-  - Request to be unstaked from the network. The unstake request will sit in a pending status for two epochs. Once it is processed, the amount that has been unstaked will sit in your unstaked FLOW amount and can now be withdrawn or re-staked.
-  - Change the node you are staked/delegated to. If your staked/delegated node has no FLOW actively staked and you have completely withdrawn all unstaked amounts and rewards associated with the node, then you can move your stake to a different node. Click on the `Change Node` button to initiate this process. Please note that this feature is only visible once you get your active stake/delegate into the appropriate status.
+
+- Add additional stake to your existing stake. Any added FLOW will again sit in a pending status and be processed at the next epoch.
+- Withdraw/re-stake your earned rewards. If you decide to withdraw your rewards, this action will happen instantly. If you decide to re-stake your rewards, the request will again sit in a pending status and will be processed at the next [Epoch](../../networks/staking/index.md#epochs).
+- Withdraw Rewards and send your earnings to other accounts. If you decide that you want to withdraw your rewards and send those earnings to other accounts via the 'Send FLOW' function, you should first withdraw your rewards. Once in your account, you can send these funds to any other account via the 'Send FLOW' option.
+- Request to be unstaked from the network. The unstake request will sit in a pending status for two epochs. Once it is processed, the amount that has been unstaked will sit in your unstaked FLOW amount and can now be withdrawn or re-staked.
+- Change the node you are staked/delegated to. If your staked/delegated node has no FLOW actively staked and you have completely withdrawn all unstaked amounts and rewards associated with the node, then you can move your stake to a different node. Click on the `Change Node` button to initiate this process. Please note that this feature is only visible once you get your active stake/delegate into the appropriate status.
 
 ## FAQs
-  1. Why do I have multiple 'Keys' on my account?
 
-     If you created your account with Blocto, you will see that you have multiple keys that exist on your account in the 'Dashboard':
+1. Why do I have multiple 'Keys' on my account?
 
-     1 with weight 1 (device key): This is generated on Blocto and sent to users' device when they login  with email.
-     1 with weight 999 (Blocto service key): This is kept in Blocto's secure key management service and is used to sign transaction.
-     1 with weight 1000 (recovery key): This is kept in Blocto's secure key management service and is only used when user wants to switch to non-custodial mode.
+   If you created your account with Blocto, you will see that you have multiple keys that exist on your account in the 'Dashboard':
 
-     Normally if a user wants to send a Flow transaction, it requires signature from both the key on users' device and a key from Blocto service. Making it harder for hackers to steal your assets.
+   1 with weight 1 (device key): This is generated on Blocto and sent to users' device when they login with email.
+   1 with weight 999 (Blocto service key): This is kept in Blocto's secure key management service and is used to sign transaction.
+   1 with weight 1000 (recovery key): This is kept in Blocto's secure key management service and is only used when user wants to switch to non-custodial mode.
 
-  2. Where can I find a list of node operators to delegate to?
+   Normally if a user wants to send a Flow transaction, it requires signature from both the key on users' device and a key from Blocto service. Making it harder for hackers to steal your assets.
 
-     - a.) Please see a list [here](https://github.com/onflow/flow/blob/master/nodeoperators/NodeOperatorList.md) for all node operators that you can delegate to. This list will be updated as new node operators are onboarded onto the network.
+2. Where can I find a list of node operators to delegate to?
 
-  3. I am currently running a node on the network already and have already gone through the staking process once. Do I need to execute a new stake every time there is a new epoch?
+   - a.) Please see a list [here](https://github.com/onflow/flow/blob/master/nodeoperators/NodeOperatorList.md) for all node operators that you can delegate to. This list will be updated as new node operators are onboarded onto the network.
 
-       - a.) Once you successfully stake your node and become part of the network, you do not need to submit a new staking request each and every epoch. Your node will be automatically staked from epoch to epoch. This also means that your Node ID will remain the same from epoch to epoch. If you want to unstake your node from the network, then you will follow the process of unstaking your node.
+3. I am currently running a node on the network already and have already gone through the staking process once. Do I need to execute a new stake every time there is a new epoch?
 
-  4. I have a Blocto account and I see that I can stake both in Flow Port and in Blocto's mobile app. What is the difference?
+   - a.) Once you successfully stake your node and become part of the network, you do not need to submit a new staking request each and every epoch. Your node will be automatically staked from epoch to epoch. This also means that your Node ID will remain the same from epoch to epoch. If you want to unstake your node from the network, then you will follow the process of unstaking your node.
 
-       - a.) If you go through Flow Port, you can choose any node operator within the Flow network to delegate any amount of your Flow Tokens to. If you go through Blocto's mobile site, you will only be able to stake to Blocto run nodes. You can read more about Blocto's staking process by referencing [here](https://guide.blocto.app/article/stake-flow-tokens-step-by-step-with-blocto).
+4. I have a Blocto account and I see that I can stake both in Flow Port and in Blocto's mobile app. What is the difference?
 
-  5. Do I need to use my Ledger device to view information about my account (e.g. my balance and current staked or delegated FLOW)?
+   - a.) If you go through Flow Port, you can choose any node operator within the Flow network to delegate any amount of your Flow Tokens to. If you go through Blocto's mobile site, you will only be able to stake to Blocto run nodes. You can read more about Blocto's staking process by referencing [here](https://guide.blocto.app/article/stake-flow-tokens-step-by-step-with-blocto).
 
-       - a.) No you do not! You only need your Ledger device to sign transactions. If you want to view your account, you can do so without your Ledger. You can do this by navigating directly to the appropriate desired page URL, while inputting your address into the URL itself. For quick reference, below is a list of these URLs and where you would input your address:
-       - Dashboard: https://port.onflow.org/account/[AccountAddress]
-       - Stake & Delegate: https://port.onflow.org/stake-delegate/[AccountAddress]
+5. Do I need to use my Ledger device to view information about my account (e.g. my balance and current staked or delegated FLOW)?
 
-  6. I am clicking 'submit' to execute a transaction, but nothing is happening. How can I unblock myself?
+   - a.) No you do not! You only need your Ledger device to sign transactions. If you want to view your account, you can do so without your Ledger. You can do this by navigating directly to the appropriate desired page URL, while inputting your address into the URL itself. For quick reference, below is a list of these URLs and where you would input your address:
+   - Dashboard: https://port.flow.com/account/[AccountAddress]
+   - Stake & Delegate: https://port.flow.com/stake-delegate/[AccountAddress]
 
-       - a.) Please disable any pop-up blockers and ad blockers you have and refresh the page. If you are still experiencing issues, please reach out via [Discord](https://discord.gg/flow) in the appropriate channel.
+6. I am clicking 'submit' to execute a transaction, but nothing is happening. How can I unblock myself?
+
+   - a.) Please disable any pop-up blockers and ad blockers you have and refresh the page. If you are still experiencing issues, please reach out via [Discord](https://discord.gg/flow) in the appropriate channel.

--- a/docs/networks/node-ops/node-operation/faq.md
+++ b/docs/networks/node-ops/node-operation/faq.md
@@ -11,7 +11,7 @@ Anyone can run an [observer node](../light-nodes/observer-node.md).
 
 Anyone can run an Access Node after registering and staking. See [Access Node Setup](../access-nodes/access-node-setup.md) for detailed instructions.
 
-For the other node roles, individuals can go through an application process that involves asking about their background and experience contributing to decentralized projects. To pursue an application, please visit [the Flow website here to apply](https://www.onflow.org/node-validators).
+For the other node roles, individuals can go through an application process that involves asking about their background and experience contributing to decentralized projects. To pursue an application, please visit [the Flow website here to apply](https://www.flow.com/node-validators).
 
 Pending approval, new node operators will be onboarded and invited to join a webinar to meet the team and share more about how they’ll grow the community. Node Operators are invited to join and participate in Flow's Node Validator Discord channel for setup questions and network announcements.
 
@@ -27,7 +27,7 @@ Please follow the instructions provided here: [Monitoring nodes](./monitoring-no
 
 ### Can I bootstrap and run a node at any time?
 
-Flow allows nodes to join/leave the network each time a new epoch begins (roughly once per week). 
+Flow allows nodes to join/leave the network each time a new epoch begins (roughly once per week).
 See [Staking & Epochs](../../staking/index.md#epochs) for general information and [Node Setup](./node-bootstrap.md#timing) for a guide to running a new node.
 
 ### Would it hurt the network to have a node that constantly spins up and down?

--- a/docs/tutorials/native-vrf/commit-reveal-cadence.md
+++ b/docs/tutorials/native-vrf/commit-reveal-cadence.md
@@ -261,8 +261,8 @@ This tutorial has equipped you with hands-on experience and key skills:
 By harnessing the built-in randomness capabilities on Flow, you can now focus on crafting engaging, user-centric experiences without grappling with the complexities or limitations of external systems. This knowledge empowers you to create secure, scalable, and fair decentralized applications.
 
 [chainlink-vrf]: https://docs.chain.link/vrf
-[flow-faucet]: https://testnet-faucet.onflow.org/
-[flow-docs]: https://docs.onflow.org/flow-cli/install/
+[flow-faucet]: https://faucet.flow.com/fund-account
+[flow-docs]: https://docs.flow.com/flow-cli/install/
 [flow-diver]: https://testnet.flowdiver.io/
 [github-repo]: https://github.com/onflow/random-coin-toss
 [run-dnz]: https://run.dnz.dev/

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -382,7 +382,7 @@ const config = {
                 label: 'Ecosystem',
               },
               {
-                href: 'https://port.onflow.org/',
+                href: 'https://port.flow.com/',
                 label: 'Flow Port',
               },
               {
@@ -419,7 +419,7 @@ const config = {
                 label: 'Cadence Tutorials',
               },
               {
-                href: 'https://open-cadence.onflow.org',
+                href: 'https://cookbook.flow.com',
                 label: 'Cadence Cookbook',
               },
               {
@@ -436,7 +436,7 @@ const config = {
             title: 'Network',
             items: [
               {
-                href: 'https://status.onflow.org/',
+                href: 'https://status.flow.com/',
                 label: 'Network Status',
               },
               {
@@ -477,12 +477,12 @@ const config = {
                 label: 'Discord',
               },
               {
-                href: 'https://forum.onflow.org/',
+                href: 'https://forum.flow.com/',
                 label: 'Forum',
               },
               {
-                href: 'https://onflow.org/',
-                label: 'OnFlow',
+                href: 'https://flow.com/',
+                label: 'Flow',
               },
               {
                 href: 'https://flow.com/blog',

--- a/src/data/articles/index.ts
+++ b/src/data/articles/index.ts
@@ -116,7 +116,7 @@ export const flowMultiNodeArchitecture: TutorialCardProps = {
   heading: "Flow's Multi-Node Architecture",
   tags: ['architecture', 'intermediate'],
   description: `A deep dive into how Flow's multi-node architecture scales to millions, increases decentralization, and ensures a great end-user experience`,
-  link: 'https://www.onflow.org/post/flow-blockchain-multi-node-architecture-advantages',
+  link: 'https://www.flow.com/post/flow-blockchain-multi-node-architecture-advantages',
   imageUri:
     'https://assets.website-files.com/5f6294c0c7a8cdf432b1c827/6143728c4909ca0adba869a4_Flow_Blog-Inside%20Flow.png',
   lastUpdated: '16/09/2021',

--- a/src/data/external-links.ts
+++ b/src/data/external-links.ts
@@ -1,7 +1,7 @@
 export const externalLinks = {
   discord: 'https://discord.gg/flow',
-  discourse: 'https://forum.onflow.org/',
-  flow: 'https://onflow.org/',
+  discourse: 'https://forum.flow.com/',
+  flow: 'https://flow.com/',
   github: 'https://github.com/onflow',
   twitter: 'https://twitter.com/flow_blockchain',
   youtube: 'https://www.youtube.com/c/FlowBlockchain',

--- a/src/ui/design-system/src/lib/Components/EventCardSmall/EventCardSmall.stories.tsx
+++ b/src/ui/design-system/src/lib/Components/EventCardSmall/EventCardSmall.stories.tsx
@@ -15,7 +15,7 @@ const Template: Story<EventCardSmallProps> = (args) => {
 
 export const Default = Template.bind({})
 Default.args = {
-  href: "https://www.onflow.org",
+  href: "https://www.flow.com",
   eventType: "Online",
   imageSrc:
     "https://assets.website-files.com/5f6294c0c7a8cdf432b1c827/61410bc0c8d0522eea319058_Hack-blog_Flow.png",

--- a/src/ui/design-system/src/lib/Components/LinkCard2Column/LinkCard2Column.stories.tsx
+++ b/src/ui/design-system/src/lib/Components/LinkCard2Column/LinkCard2Column.stories.tsx
@@ -26,7 +26,7 @@ Default.args = {
       title: "Title Here 1 Line Only",
       description:
         "A package used to interact with user wallets and the Flow blockchain.",
-      href: "https://www.onflow.org",
+      href: "https://www.flow.com",
       iconType: "cadence",
     },
     {
@@ -50,7 +50,7 @@ Default.args = {
         },
         {
           title: "External link",
-          href: "https://www.onflow.org",
+          href: "https://www.flow.com",
         },
       ],
     },

--- a/src/ui/design-system/src/lib/Components/NetworkDetailsCard/index.tsx
+++ b/src/ui/design-system/src/lib/Components/NetworkDetailsCard/index.tsx
@@ -61,7 +61,7 @@ const NetworkDetailsCard = ({
           </p>
           {/* @ts-expect-error */}
           <InternalContentLink
-            href="https://status.onflow.org"
+            href="https://status.flow.com"
             className="flex items-center hover:opacity-75"
           >
             <RssIcon />

--- a/src/ui/design-system/src/lib/Components/PageCarousel/index.tsx
+++ b/src/ui/design-system/src/lib/Components/PageCarousel/index.tsx
@@ -72,7 +72,7 @@ const cards = {
       subtitle: 'A smart contract tutorial for Cadence.',
       imageName: 'cadence-playground',
       hoverText: 'Get Started',
-      link: 'https://play.onflow.org/',
+      link: 'https://play.flow.com/',
     },
   ],
 };

--- a/src/ui/design-system/src/lib/Components/UpcomingEvents/UpcomingEvents.stories.tsx
+++ b/src/ui/design-system/src/lib/Components/UpcomingEvents/UpcomingEvents.stories.tsx
@@ -21,7 +21,7 @@ const events = [
     description:
       "Come visit the Flow Booth at NFT NYC to learn more about what builders and teams have been working on!",
     eventDate: "June 20-23",
-    href: "https://share.onflow.org/nft-nyc-2022",
+    href: "https://share.flow.com/nft-nyc-2022",
     imageSrc:
       "https://510411.fs1.hubspotusercontent-na1.net/hubfs/510411/nftnyc2021-eventbrite-header.png",
     location: "Online",
@@ -43,7 +43,7 @@ const events = [
     description:
       "Join us this week at Discord office hours to learn more about Flow Tokenomics",
     eventDate: "June 30th",
-    href: "https://www.onflow.org/token-distribution",
+    href: "https://www.flow.com/token-distribution",
     imageSrc: "https://www.svgrepo.com/show/353655/discord-icon.svg",
     location: "Online",
     tags: ["Flow", "Community", "Discord"],
@@ -51,7 +51,7 @@ const events = [
   },
   {
     ctaText: "More Details",
-    href: "https://share.onflow.org/nft-nyc-2022#:~:text=Andbox%20and%20more.-,Blocto,-(3%2D6pm%20ET",
+    href: "https://share.flow.com/nft-nyc-2022#:~:text=Andbox%20and%20more.-,Blocto,-(3%2D6pm%20ET",
     description: "",
     imageSrc:
       "https://assets.website-files.com/5f6294c0c7a8cdf432b1c827/61410bc0c8d0522eea319058_Hack-blog_Flow.png",
@@ -61,7 +61,7 @@ const events = [
   },
   {
     ctaText: "More Details",
-    href: "https://share.onflow.org/nft-nyc-2022#:~:text=Building%20the%20NFT%20Marketplace%20of%20the%20Future",
+    href: "https://share.flow.com/nft-nyc-2022#:~:text=Building%20the%20NFT%20Marketplace%20of%20the%20Future",
     eventType: OFFICE_HOURS_EVENT_TYPE,
     description: "",
     imageSrc:
@@ -72,7 +72,7 @@ const events = [
   },
   {
     ctaText: "More Details",
-    href: "https://share.onflow.org/nft-nyc-2022#:~:text=Fireside%20Chat%20with%20Roham",
+    href: "https://share.flow.com/nft-nyc-2022#:~:text=Fireside%20Chat%20with%20Roham",
     eventType: OFFICE_HOURS_EVENT_TYPE,
     description: "",
     imageSrc:

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -1,12 +1,12 @@
 export const STATUSPAGE_API_URL =
   'https://api.statuspage.io/v1/pages/ytw5bdg6zr13/components';
 export const DISCOURSE_BREAKING_CHANGES_URL =
-  'https://forum.onflow.org/c/announcements/breaking-changes/30.json';
+  'https://forum.flow.com/c/announcements/breaking-changes/30.json';
 export const DISCOURSE_MAINNET_SPORK_URL =
-  'https://forum.onflow.org/c/mainnet-sporks/36.json';
+  'https://forum.flow.com/c/mainnet-sporks/36.json';
 export const DISCOURSE_LATEST_TOPICS_URL =
-  'https://forum.onflow.org/latest.json';
-export const DISCOURSE_API_URL = 'https://forum.onflow.org';
+  'https://forum.flow.com/latest.json';
+export const DISCOURSE_API_URL = 'https://forum.flow.com';
 export const POLLING_INTERVAL_FIVE_SECONDS = 5 * 1000;
 
 export const ABOUT_THIS_CATEGORY_BREAKING_CHANGES = 762;

--- a/src/utils/env.server.ts
+++ b/src/utils/env.server.ts
@@ -40,7 +40,7 @@ export function getPublicEnv() {
   return {
     NODE_ENV: process.env.NODE_ENV,
     /**
-     * the url origin, e.g. https://developers.onflow.org or http://localhost:3000
+     * the url origin, e.g. https://developers.flow.com or http://localhost:3000
      */
     ORIGIN: process.env.ORIGIN || getFallbackOrigin(),
     LOG_WEB_VITALS: process.env.LOG_WEB_VITALS,


### PR DESCRIPTION
Change onflow.org to flow.com where appropriate.

Did not change for fcl-discovery, rpc nodes, etc. because those still use onflow.org