### PR TITLE
add pyusd info for defi

### DIFF
--- a/docs/ecosystem/defi-liquidity/defi-contracts.md
+++ b/docs/ecosystem/defi-liquidity/defi-contracts.md
@@ -71,6 +71,25 @@ Below is a list of commonly used DeFi contracts on Flow:
 | LayerZero                                    | [Mainnet Contracts][16]  |
 | Axelar                                       | [Axelar Docs][17]        |
 
+## Omni Fungible Tokens
+
+#### Solana Mainnet
+
+| Contract Name                | Contract Address                           |
+|------------------------------|--------------------------------------------|
+| PYUSD Program ID             | `28EyPNAi9BMTvGuCaQrptMXjpWUi7wx8SxAFVoSZxSXe` |
+| PYUSD Mint                   | `2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo` |
+| PYUSD Mint Authority         | `22mKJkKjGEQ3rampp5YKaSsaYZ52BUkcnUN6evXGsXzz` |
+| PYUSD Escrow                 | `6z3QyVS36nQ9fk2YvToxqJqXqtAFsSijqgHxpzKyG5xn` |
+| PYUSD OFT Store              | `2KUb8dcZR9LyrSg4RdkQx91xX6mPQLpS1MEo6gwfvLZk` |
+
+#### Ethereum Mainnet
+
+| Contract Name                | Contract Address                           |
+|------------------------------|--------------------------------------------|
+| PYUSD Token                  | `0x6c3ea9036406852006290770BEdFcAbA0e23A0e8` |
+| PYUSD Locker                 | `0xFA0e06B54986ad96DE87a8c56Fea76FBD8d493F8` |
+
 ## Oracles
 
 #### Flow EVM Mainnet

--- a/docs/ecosystem/defi-liquidity/defi-contracts.md
+++ b/docs/ecosystem/defi-liquidity/defi-contracts.md
@@ -71,7 +71,7 @@ Below is a list of commonly used DeFi contracts on Flow:
 | LayerZero                                    | [Mainnet Contracts][16]  |
 | Axelar                                       | [Axelar Docs][17]        |
 
-## Omni Fungible Tokens
+## Omni Fungible Tokens (USD Flow - USDF)
 
 #### Solana Mainnet
 


### PR DESCRIPTION
Add OFT information for USDF tokens
This pull request updates the documentation for DeFi contracts by adding a new section for Omni Fungible Tokens (OFT) on Solana and Ethereum mainnets. It provides contract names and their corresponding addresses for these tokens.

### Documentation updates:

* Added a new "Omni Fungible Tokens" section to the DeFi contracts documentation. This includes detailed tables for:
  - **Solana Mainnet**: Lists contracts such as `PYUSD Program ID`, `PYUSD Mint`, `PYUSD Mint Authority`, `PYUSD Escrow`, and `PYUSD OFT Store`, along with their addresses.
  - **Ethereum Mainnet**: Lists contracts such as `PYUSD Token` and `PYUSD Locker`, along with their addresses.