### PR TITLE
missing closing parenthesis

### DIFF
--- a/docs/evm/guides/wagmi.md
+++ b/docs/evm/guides/wagmi.md
@@ -127,6 +127,7 @@ function App() {
         <div>{error?.message}</div>
       </div>
     </>
+  )
 }
 
 export default App


### PR DESCRIPTION
Step 2: Configuring Wagmi and Connecting the Wallet.

The page.tsx code is missing a closing parenthesis.