### PR TITLE
Fix video embedding URL format in Cadence rules guide

### DIFF
--- a/docs/blockchain-development-tutorials/use-AI-to-build-on-flow/cursor/cadence-rules.md
+++ b/docs/blockchain-development-tutorials/use-AI-to-build-on-flow/cursor/cadence-rules.md
@@ -24,7 +24,7 @@ In this guide, you'll learn how to configure and use Cursor Rules that transform
 <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%' }}>
   <iframe 
     style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
-    src="https://www.youtube.com/watch?v=cFC8b-pdJ8g" 
+    src="https://www.youtube.com/embed/cFC8b-pdJ8g" 
     title="YouTube video player" 
     frameborder="0" 
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 


### PR DESCRIPTION
## Summary

- Fix YouTube video embedding URL format in the Cadence rules guide
- Change URL from `watch?v=` format to `embed/` format for proper Docusaurus display

## Changes

- Updated `docs/blockchain-development-tutorials/use-AI-to-build-on-flow/cursor/cadence-rules.md`
- Changed `https://www.youtube.com/watch?v=cFC8b-pdJ8g` to `https://www.youtube.com/embed/cFC8b-pdJ8g`

## Test plan

- [ ] Verify video displays correctly in documentation site
- [ ] Check that video maintains responsive design