### PR TITLE
docs: add t3rn details to bridges documentation

### DIFF
--- a/docs/ecosystem/bridges.md
+++ b/docs/ecosystem/bridges.md
@@ -51,6 +51,9 @@ Bridges are mechanisms that connect different blockchain networks, enabling secu
 
 [Bridge.Flow.com][12] is a digital asset bridge powered by Superbridge, specifically designed to connect Ethereum and Flow EVM Mainnet. It provides secure and efficient asset transfers between these two major blockchain networks, enabling seamless interoperability for users and developers.
 
+## t3rn
+[t3rn][13] is a programmable cross-chain execution layer designed for low-cost settlements, averaging just $0.005 per transaction. Orders are trustlessly validated with Merkle Patricia Trie (MPT) proofs from each network and anchored to t3rn’s chain, enabling developers to build sophisticated, interoperable applications on a unified metalayer.
+
 </div>
 
 [1]: https://stargate.finance/bridge
@@ -65,3 +68,4 @@ Bridges are mechanisms that connect different blockchain networks, enabling secu
 [10]: https://relay.link/bridge
 [11]: https://relay.link/
 [12]: https://bridge.flow.com/
+[13]: https://bridge.t3rn.io/


### PR DESCRIPTION
Added information about t3rn as a cross-chain execution layer.