### PR TITLE
Update note for connecting to Flow mainnet

### DIFF
--- a/docs/blockchain-development-tutorials/evm/frameworks/ethers.md
+++ b/docs/blockchain-development-tutorials/evm/frameworks/ethers.md
@@ -43,7 +43,7 @@ const url = 'https://testnet.evm.nodes.onflow.org/';
 const provider = new ethers.providers.JsonRpcProvider(url);
 ```
 
-**Note:** If you want to connect to the Flow testnet, replace the above URL with `https://mainnet.evm.nodes.onflow.org`.
+**Note:** If you want to connect to the Flow mainnet, replace the above URL with `https://mainnet.evm.nodes.onflow.org`.
 
 ## Reading Data from the Blockchain
 


### PR DESCRIPTION
I was going though the docs and found this small typo. 
  
<img width="831" height="340" alt="Screenshot 2025-10-09 212227" src="https://github.com/user-attachments/assets/88423f62-09a4-473c-a520-0a977d95ee3e" />

I think mainnet should be the correct phrase. 