### PR TITLE
Remove prerelease disclaimer for scheduled transactions

### DIFF
--- a/docs/blockchain-development-tutorials/forte/scheduled-transactions/scheduled-transactions-introduction.md
+++ b/docs/blockchain-development-tutorials/forte/scheduled-transactions/scheduled-transactions-introduction.md
@@ -17,14 +17,6 @@ keywords:
 
 # Introduction to Scheduled Transactions
 
-:::warning
-
-Scheduled transactions are a new feature that is under development and is a part of [FLIP 330]. Currently, they only work in the emulator and testnet. We're close to finishing the specific implementation, but it but may change during the development process.
-
-We will update these tutorials, but you may need to refactor your code if the implementation changes.
-
-:::
-
 # Overview
 
 Flow, EVM, and other blockchains are a form of a **single** shared computer that anyone can use, with no admin privileges, super user roles, or complete control. For this to work, it must be impossible for any user to freeze the computer, on purpose or by accident.

--- a/docs/build/cadence/advanced-concepts/scheduled-transactions.md
+++ b/docs/build/cadence/advanced-concepts/scheduled-transactions.md
@@ -19,7 +19,7 @@ sidebar_position: 8
 ## Introduction
 
 :::warning
-Scheduled transactions are part of the Forte network upgrade and are currently available on Flow Emulator (CLI v2.7.0+) and [Flow Testnet]. See the announcement for context: [Forte: Introducing Actions & Agents].
+Scheduled transactions were part of the Forte network upgrade and are available on Flow Mainnet, Flow Emulator (CLI v2.7.0+) and [Flow Testnet]. See the announcement for context: [Forte: Introducing Actions & Agents].
 :::
 
 Scheduled transactions on the Flow blockchain enable users and smart contracts to autonomously execute predefined logic at specific future times without external triggers. This powerful feature allows developers to create "wake up" patterns where contracts can schedule themselves to run at predetermined block timestamps, enabling novel blockchain automation patterns.


### PR DESCRIPTION
Removes mentions that scheduled transactions aren't available on mainnet yet