### PR TITLE
Adopt Content Signals Policy in robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,8 +1,19 @@
+# developers.flow.com robots.txt
 # algolia: 98E1096D4FD67E70
+#
+# Content Signals Policy (contentsignals.org, 2025) — explicitly permit
+# search indexing, live AI retrieval (ChatGPT / Claude / Perplexity / etc.
+# citation), and AI training on all content. Flow developer docs are
+# open source and intended to be maximally discoverable by humans and
+# AI agents.
 
-# Allow all bots
 User-agent: *
-Disallow:
+# Content-Signal: search=yes, ai-input=yes, ai-train=yes
+Allow: /
 
-# Sitemap
 Sitemap: https://developers.flow.com/sitemap.xml
+
+# Machine-readable AI indexes (complementary, non-standard):
+#   Curated index:   https://developers.flow.com/llms.txt
+#   Full corpus:     https://developers.flow.com/llms-full.txt
+#   Companion site:  https://cadence-lang.org/llms.txt


### PR DESCRIPTION
## Summary

Adds an explicit [Content Signals Policy](https://contentsignals.org/) declaration to `static/robots.txt`:

- `search=yes` — appear in traditional search indexes
- `ai-input=yes` — used in live AI retrieval / citation (ChatGPT, Claude, Perplexity, etc.)
- `ai-train=yes` — used to train or fine-tune AI models

The Content Signals Policy — [rolled out by Cloudflare](https://blog.cloudflare.com/content-signals-policy/) to 3.8M+ domains since Sept 2025 — is the emerging post-user-agent-allowlist mechanism for expressing AI policy in `robots.txt`. Flow developer docs are open source and we want maximum discoverability for humans and AI agents, so all three signals are set to `yes`.

## What this is NOT

- Not a verbose AI-bot allowlist. Every major dev-docs site audited (Mintlify, Supabase, Vercel, Anthropic, OpenAI, Stripe, Python docs, Cloudflare, developers.google.com) uses wildcard + targeted disallows rather than enumerating bots. Per-bot allowlists drift quickly (e.g., Anthropic deprecated `anthropic-ai` in favor of `Claude-User` / `Claude-SearchBot`).
- Not a functional change to who can crawl. The current file already allows everything via `User-agent: *` / `Disallow:`. This PR just adds the explicit AI policy declaration.

## Test plan

- [x] File serves locally and on prod already (this is a minor metadata/comment addition)
- [ ] Verify Vercel preview serves the updated file before merge
- [ ] Spot-check: `curl https://<preview>/robots.txt` returns the new content

## Companion work

A parallel PR on onflow/cadence-lang.org ([#292](https://github.com/onflow/cadence-lang.org/pull/292)) applies the same Content Signals policy plus adds llms.txt generation. These two sites should stay in lockstep on AI policy.