### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -235,6 +235,8 @@ const config = {
     ],
   ],
 
+  plugins: ['docusaurus-plugin-copy-page-button'],
+
   themes: [hasTypesense && 'docusaurus-theme-search-typesense'].filter(Boolean),
 
   themeConfig:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@tailwindcss/typography": "0.5.19",
     "autoprefixer": "10.4.21",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.6.1",
     "docusaurus-theme-search-typesense": "^0.25.0",
     "dotenv": "^17.2.3",
     "eslint-config-prettier": "^10.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7532,6 +7532,11 @@ docusaurus-plugin-redoc@2.5.0:
     "@redocly/openapi-core" "1.16.0"
     redoc "2.4.0"
 
+docusaurus-plugin-copy-page-button@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.6.1.tgz#901bc9fed88eb8afda5838c634e81a69d312db54"
+  integrity sha512-84LUG23owdGlUx5rgg7lcyuuxFZ+84u9u+adYjFZ1E5lM+g6bkduOGcZXLUqbI0R2Ve2RjG0OPv2KaL01tGW4w==
+
 docusaurus-theme-redoc@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/docusaurus-theme-redoc/-/docusaurus-theme-redoc-2.5.0.tgz#b8d6f033a7d88485c0d86b3b28c0a98a5d7a8900"


### PR DESCRIPTION
## Summary
- add `docusaurus-plugin-copy-page-button` to the docs dependencies
- register the plugin in `docusaurus.config.js`

## Why
Flow docs include developer workflows and reference material that are useful to bring into AI tools. This adds a page-level copy/open button that exports the current page as clean markdown and includes one-click Open in ChatGPT, Claude, and Gemini actions.

The plugin has no runtime dependencies and uses peer dependencies for Docusaurus and React. It is already used by docs sites including Sui, Monad, Flare, Kaia, Nillion, Chronicle, Cardano, Arbitrum, Ethereum execution-apis, and Puppeteer.

## Validation
- `git diff --check`
- package manifest, lockfile, and config sanity check

Not run locally: full docs build, due the dependency install/build footprint in this environment.