### PR TITLE
Remove stopped access nodes (002, 003, 004) from docs

### DIFF
--- a/docs/protocol/node-ops/light-nodes/observer-node.md
+++ b/docs/protocol/node-ops/light-nodes/observer-node.md
@@ -269,10 +269,5 @@ Access-001:
 - Host: `access-001.[current devnet spork].nodes.onflow.org`
 - Public Key: `ba69f7d2e82b9edf25b103c195cd371cf0cc047ef8884a9bbe331e62982d46daeebf836f7445a2ac16741013b192959d8ad26998aff12f2adc67a99e1eb2988d`
 
-Access-003:
-
-- Host: `access-003.[current devnet spork].nodes.onflow.org`
-- Public Key: `b662102f4184fc1caeb2933cf87bba75cdd37758926584c0ce8a90549bb12ee0f9115111bbbb6acc2b889461208533369a91e8321eaf6bcb871a788ddd6bfbf7`
-
 While the public keys remain the same, the hostnames change each spork to include the spork name. Substitute `[current mainnet spork]` and `[current devnet spork]` with the appropriate spork name (e.g. `mainnet20`).
 See [Past Sporks](../node-operation/past-upgrades) for the current spork for each network.

--- a/docs/protocol/node-ops/node-operation/node-setup.md
+++ b/docs/protocol/node-ops/node-operation/node-setup.md
@@ -147,7 +147,7 @@ docker run --rm \
 	--ingress-addr=0.0.0.0:9000 \
 	--admin-addr=0.0.0.0:9002 \
 	--bind 0.0.0.0:3569 \
-	--access-node-ids=4e17496619df8bb4dcd579c252d9fb026e54995db0dc6825bdcd27bd3288a990 \
+	--access-node-ids=4e17496619df8bb4dcd579c252d9fb026e54995db0dc6825bdcd27bd3288a990,c0710209b76bd840f0f4c1fb66f6863a712581f39b5b09b96c91e50a3f206c0e,1f46b4d23c7557e7b3c21f85aebddcb7bcda7cc4d589732ce53087cb1b5faf8e \
 	--gossipsub-peer-scoring-enabled=false  \
 	--gossipsub-peer-gater-enabled=true \
 	--loglevel=error
@@ -169,7 +169,7 @@ docker run --rm \
 	--secretsdir=/data/secrets \
 	--admin-addr=0.0.0.0:9002 \
 	--bind 0.0.0.0:3569 \
-	--access-node-ids=4e17496619df8bb4dcd579c252d9fb026e54995db0dc6825bdcd27bd3288a990 \
+	--access-node-ids=4e17496619df8bb4dcd579c252d9fb026e54995db0dc6825bdcd27bd3288a990,c0710209b76bd840f0f4c1fb66f6863a712581f39b5b09b96c91e50a3f206c0e,1f46b4d23c7557e7b3c21f85aebddcb7bcda7cc4d589732ce53087cb1b5faf8e \
 	--gossipsub-peer-scoring-enabled=false  \
 	--gossipsub-peer-gater-enabled=true \
 	--loglevel=error

--- a/docs/protocol/node-ops/node-operation/node-setup.md
+++ b/docs/protocol/node-ops/node-operation/node-setup.md
@@ -147,7 +147,7 @@ docker run --rm \
 	--ingress-addr=0.0.0.0:9000 \
 	--admin-addr=0.0.0.0:9002 \
 	--bind 0.0.0.0:3569 \
-	--access-node-ids=4e17496619df8bb4dcd579c252d9fb026e54995db0dc6825bdcd27bd3288a990,7e3fe64ccc119f578a7795df8b8c512e05409bdc7de4f74259c6f48351fecb26,416c65782048656e74736368656c009530ef3ab4b8bf83b24df54fe5f81853de,416e647265772042757269616e00d219355d62b9adad8ebd3fab223a1cf84c22 \
+	--access-node-ids=4e17496619df8bb4dcd579c252d9fb026e54995db0dc6825bdcd27bd3288a990 \
 	--gossipsub-peer-scoring-enabled=false  \
 	--gossipsub-peer-gater-enabled=true \
 	--loglevel=error
@@ -169,7 +169,7 @@ docker run --rm \
 	--secretsdir=/data/secrets \
 	--admin-addr=0.0.0.0:9002 \
 	--bind 0.0.0.0:3569 \
-	--access-node-ids=4e17496619df8bb4dcd579c252d9fb026e54995db0dc6825bdcd27bd3288a990,7e3fe64ccc119f578a7795df8b8c512e05409bdc7de4f74259c6f48351fecb26,416c65782048656e74736368656c009530ef3ab4b8bf83b24df54fe5f81853de,416e647265772042757269616e00d219355d62b9adad8ebd3fab223a1cf84c22 \
+	--access-node-ids=4e17496619df8bb4dcd579c252d9fb026e54995db0dc6825bdcd27bd3288a990 \
 	--gossipsub-peer-scoring-enabled=false  \
 	--gossipsub-peer-gater-enabled=true \
 	--loglevel=error


### PR DESCRIPTION
## Summary

- Removed access-002, access-003, and access-004 node IDs from `--access-node-ids` in node setup examples (collection and consensus nodes) in `node-setup.md`
- Removed testnet Access-003 entry from the observer/light node setup guide in `observer-node.md`; Access-001 remains as the only active testnet node for light node connections

## Test plan

- [ ] Verify `node-setup.md` collection and consensus examples only list access-001 node ID
- [ ] Verify `observer-node.md` testnet section only lists Access-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)