### PR TITLE
Remove deBridge references from docs

### DIFF
--- a/docs/defi/cross-chain-swaps.md
+++ b/docs/defi/cross-chain-swaps.md
@@ -12,7 +12,6 @@ keywords:
   - Flow EVM
   - EVM
   - Relay.link
-  - DeBridge
   - Stargate
   - LayerZero
   - Celer
@@ -43,8 +42,3 @@ Intent based bridges do not depend on pre-funded liquidity pools which can impro
 ### Relay
 
 [Relay.link](https://relay.link/bridge/base) allows users to specify desired cross-chain swap outcomes for orders.
-
-### DeBridge
-
-[DeBridge](https://app.debridge.finance/) achieves efficient cross-chain swaps with minimal slippage in a decentralized environment
-through a peer-to-peer transaction mechanism.

--- a/docs/defi/defi-contracts-mainnet.md
+++ b/docs/defi/defi-contracts-mainnet.md
@@ -94,7 +94,6 @@ Below is a list of commonly used DeFi contracts on Flow Mainnet:
 | Hyperlane Bridge ([trump.hyperlane.xyz][10]) | [Mainnet Contracts][11]  |
 | Flow Bridge ([bridge.flow.com][12])          | [Superbridge Docs][13]   |
 | Celer cBridge ([cbridge.celer.network][14])  | [Celer cBridge Docs][15] |
-| DeBridge ([app.debridge.finance][34])        | [DeBridge Contracts][35] |
 | Relay ([relay.link][36])                     | [Relay Contracts][37]    |
 | LayerZero                                    | [Mainnet Contracts][16]  |
 | Axelar                                       | [Axelar Docs][17]        |
@@ -176,8 +175,6 @@ More information can be found on the Credora docs site for [EAS on Flow](https:/
 [31]: https://testnet.flowscan.io/contract/A.8232ce4a3aff4e94.PublicPriceOracle
 [32]: https://testnet.flowscan.io/contract/A.9fb6606c300b5051.BandOracle
 [33]: https://flowscan.io/contract/A.6801a6222ebf784a.BandOracle
-[34]: https://app.debridge.finance/
-[35]: https://docs.debridge.finance/dln-the-debridge-liquidity-network-protocol/deployed-contracts
 [36]: https://relay.link/bridge
 [37]: https://docs.relay.link/resources/contract-addresses
 [band-oracle-doc]: ./band-oracle

--- a/docs/ecosystem/bridges.md
+++ b/docs/ecosystem/bridges.md
@@ -35,21 +35,17 @@ Bridges are mechanisms that connect different blockchain networks, enabling secu
 
 [Axelar][7] is a decentralized cross-chain network connecting over 55 blockchains, facilitating asset transfers and smart contract programmability. It features a proof-of-stake consensus for security and supports cross-chain applications through General Message Passing (GMP). Integrations with platforms like [Squid][8] enable easy token swaps across networks like Ethereum and Polygon.
 
-## DeBridge
-
-[DeBridge][9] is a decentralized cross-chain network supporting hundreds of tokens over 75 blockchains. DeBridge runs on its generic messaging protocol and operates cross-chain validator infrastructure to achieve a high level cross-chain interoperability for quick, low-cost bridging. DeBridge's architecture emphasizes security and fault tolerance with robust handling of forks or blockchain outages to mitigate bridging issues.
-
 ## Relay
 
-[Relay][10] is an intent-based bridge enabling high-speed bridging and connecting over 30 blockchains. Unlike consensus validator based decentralized bridges, Relay's permissioned relayer model stores outbound tokens on the origin chain and issues tokens on the destination chain allowing for low-cost, fast bridging of assets.
+[Relay][9] is an intent-based bridge enabling high-speed bridging and connecting over 30 blockchains. Unlike consensus validator based decentralized bridges, Relay's permissioned relayer model stores outbound tokens on the origin chain and issues tokens on the destination chain allowing for low-cost, fast bridging of assets.
 
 ## Relay.link
 
-[Relay.link][11] provides instant, low-cost swapping, bridging, and cross-chain execution across 73+ chains. It offers a comprehensive solution for users looking to bridge assets and execute cross-chain transactions with minimal fees and maximum efficiency.
+[Relay.link][10] provides instant, low-cost swapping, bridging, and cross-chain execution across 73+ chains. It offers a comprehensive solution for users looking to bridge assets and execute cross-chain transactions with minimal fees and maximum efficiency.
 
 ## Bridge.Flow.com
 
-[Bridge.Flow.com][12] is a digital asset bridge powered by Superbridge, specifically designed to connect Ethereum and Flow EVM Mainnet. It provides secure and efficient asset transfers between these two major blockchain networks, enabling seamless interoperability for users and developers.
+[Bridge.Flow.com][11] is a digital asset bridge powered by Superbridge, specifically designed to connect Ethereum and Flow EVM Mainnet. It provides secure and efficient asset transfers between these two major blockchain networks, enabling seamless interoperability for users and developers.
 
 </div>
 
@@ -61,7 +57,6 @@ Bridges are mechanisms that connect different blockchain networks, enabling secu
 [6]: https://celer.network/
 [7]: https://www.axelar.network/
 [8]: https://www.squidrouter.com/
-[9]: https://app.debridge.finance/
-[10]: https://relay.link/bridge
-[11]: https://relay.link/
-[12]: https://bridge.flow.com/
+[9]: https://relay.link/bridge
+[10]: https://relay.link/
+[11]: https://bridge.flow.com/


### PR DESCRIPTION
Remove deBridge from the ecosystem bridges list, the DeFi cross-chain swaps page, and the mainnet DeFi contracts table, including associated reference links. Renumber remaining link references in bridges.md to stay sequential.