### PR TITLE
Add Envio to data indexers

### DIFF
--- a/docs/ecosystem/data-indexers.md
+++ b/docs/ecosystem/data-indexers.md
@@ -10,7 +10,7 @@ When building applications that leverage Flow data, developers have multiple Dat
 
 ### Envio
 
-[Envio](https://envio.dev/?utm_source=flow&utm_medium=partner-docs) is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Envio's HyperIndex natively supports indexing any EVM chain out of the box, so you can index Flow EVM using your own RPC as the data source. It supports event handlers in TypeScript, JavaScript, or ReScript, reorg handling, real-time and historical data, and multichain data aggregation, with fully managed hosting on Envio Cloud or self-hosting.
+[Envio](https://envio.dev/?utm_source=flow&utm_medium=partner-docs) is the data layer for blockchain apps. It gives Flow EVM developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. Envio's HyperIndex natively supports indexing any EVM chain out of the box, so you can index Flow EVM using your own RPC as the data source. It supports event handlers in TypeScript, JavaScript, or ReScript, reorg handling, real-time and historical data, and multichain data aggregation, with fully managed hosting on Envio Cloud or self-hosting.
 
 **Getting Started with Envio**
 

--- a/docs/ecosystem/data-indexers.md
+++ b/docs/ecosystem/data-indexers.md
@@ -16,8 +16,6 @@ When building applications that leverage Flow data, developers have multiple Dat
 
 You can auto-generate an indexer from any verified contract with `pnpx envio init`. For a step-by-step walkthrough, see the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=flow&utm_medium=partner-docs) and the [supported networks](https://docs.envio.dev/docs/HyperIndex/supported-networks?utm_source=flow&utm_medium=partner-docs) and [RPC data source](https://docs.envio.dev/docs/HyperIndex/rpc-sync?utm_source=flow&utm_medium=partner-docs) guides in the [Envio documentation](https://docs.envio.dev/?utm_source=flow&utm_medium=partner-docs).
 
-See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=flow&utm_medium=partner-docs).
-
 ### Moralis
 
 [Moralis](https://moralis.io/) provides a robust suite of data APIs designed to support a wide array of blockchain applications. These APIs deliver both indexed and real-time data across 16+ blockchain networks, including comprehensive details on portfolio and wallet balances, NFT data, token metrics, price feeds, candlestick charts, and net worth calculations. Moralis enhances this data with additional layers of metadata, parsed events, and address labels to provide deeper insights and context.

--- a/docs/ecosystem/data-indexers.md
+++ b/docs/ecosystem/data-indexers.md
@@ -8,6 +8,14 @@ sidebar_position: 4
 
 When building applications that leverage Flow data, developers have multiple Data Indexers to choose from. These platforms offer flexible options, allowing you to index all data on Flow, including information from both the Cadence VM and EVM. Alternatively, if your application doesn't require Cadence, you can opt to index only EVM data. This flexibility ensures that you can tailor your data indexing strategy to fit the specific needs of your application.
 
+### Envio
+
+[Envio](https://envio.dev/?utm_source=flow&utm_medium=partner-docs) is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Envio's HyperIndex natively supports indexing any EVM chain out of the box, so you can index Flow EVM using your own RPC as the data source. It supports event handlers in TypeScript, JavaScript, or ReScript, reorg handling, real-time and historical data, and multichain data aggregation, with fully managed hosting on Envio Cloud or self-hosting.
+
+**Getting Started with Envio**
+
+You can auto-generate an indexer from any verified contract with `pnpx envio init`. For a step-by-step walkthrough, see the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=flow&utm_medium=partner-docs) and the [supported networks](https://docs.envio.dev/docs/HyperIndex/supported-networks?utm_source=flow&utm_medium=partner-docs) and [RPC data source](https://docs.envio.dev/docs/HyperIndex/rpc-sync?utm_source=flow&utm_medium=partner-docs) guides in the [Envio documentation](https://docs.envio.dev/?utm_source=flow&utm_medium=partner-docs).
+
 ### Moralis
 
 [Moralis](https://moralis.io/) provides a robust suite of data APIs designed to support a wide array of blockchain applications. These APIs deliver both indexed and real-time data across 16+ blockchain networks, including comprehensive details on portfolio and wallet balances, NFT data, token metrics, price feeds, candlestick charts, and net worth calculations. Moralis enhances this data with additional layers of metadata, parsed events, and address labels to provide deeper insights and context.
@@ -23,3 +31,4 @@ To integrate Moralis into your project, begin by [creating an account](https://m
 **Getting Started with Alchemy**
 
 To begin using Alchemy, developers can [sign up for an account](https://www.alchemy.com/) on the Alchemy website. The platform offers extensive [documentation](https://docs.alchemy.com/) including API references, tutorials, and guides to help developers integrate Alchemy into their projects.
+

--- a/docs/ecosystem/data-indexers.md
+++ b/docs/ecosystem/data-indexers.md
@@ -16,6 +16,8 @@ When building applications that leverage Flow data, developers have multiple Dat
 
 You can auto-generate an indexer from any verified contract with `pnpx envio init`. For a step-by-step walkthrough, see the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=flow&utm_medium=partner-docs) and the [supported networks](https://docs.envio.dev/docs/HyperIndex/supported-networks?utm_source=flow&utm_medium=partner-docs) and [RPC data source](https://docs.envio.dev/docs/HyperIndex/rpc-sync?utm_source=flow&utm_medium=partner-docs) guides in the [Envio documentation](https://docs.envio.dev/?utm_source=flow&utm_medium=partner-docs).
 
+See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=flow&utm_medium=partner-docs).
+
 ### Moralis
 
 [Moralis](https://moralis.io/) provides a robust suite of data APIs designed to support a wide array of blockchain applications. These APIs deliver both indexed and real-time data across 16+ blockchain networks, including comprehensive details on portfolio and wallet balances, NFT data, token metrics, price feeds, candlestick charts, and net worth calculations. Moralis enhances this data with additional layers of metadata, parsed events, and address labels to provide deeper insights and context.


### PR DESCRIPTION
This adds Envio to the Data Indexers page.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Its HyperIndex framework supports indexing any EVM chain out of the box, including Flow EVM, using your own RPC as the data source, with fully managed hosting on Envio Cloud or self-hosting. The entry mirrors the existing provider sections.

Links:
- Website: https://envio.dev/
- Docs: https://docs.envio.dev/
