### PR TITLE
Add OpenChainBench RPC latency benchmark link

### DIFF
--- a/docs/protocol/flow-networks/accessing-mainnet.md
+++ b/docs/protocol/flow-networks/accessing-mainnet.md
@@ -7,6 +7,8 @@ description: Guide to mainnet access
 
 ## Accessing Flow Mainnet
 
+For live latency benchmarks across public Flow access nodes, see [OpenChainBench](https://openchainbench.com/benchmarks/flow-rpc) — p50/p90/p99 measured every 60 seconds from US-East, EU-West and Singapore.
+
 The Flow Mainnet is available for access at this URL:
 
 ```


### PR DESCRIPTION
[OpenChainBench](https://openchainbench.com) is a live RPC latency benchmark that continuously measures p50/p90/p99 response times across public blockchain endpoints from US-East, EU-West and Singapore.

This PR adds a one-line contextual reference on the mainnet access page pointing developers to the [Flow benchmark](https://openchainbench.com/benchmarks/flow-rpc) (bench 217), which measures `GET /v1/blocks?height=sealed` latency across public Flow access nodes every 60 seconds.